### PR TITLE
Fixing #13 : adding comment on using current doc as scope

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -326,248 +326,467 @@ Calculate the SHA-1 of the string "hello world".
     </div>
 </div>
 
-## list ## {#list}
-### list:append ### {#list:append}
-Appends the lists from the subject list into a single list as object.
+## math ## {#math}
+### math:absoluteValue ### {#math:absoluteValue}
+Calculates as object the absolute value of the subject.
 
-`true` if and only if `$o` is the concatenation of all lists `$s.i`.
+`true` if and only if `$o` is the absolute value of `$s`.
 
-**See also**<br><a href="#list:remove">list:remove</a>
-
-**Schema**<br>`( $s.i?[*] )+ list:append $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.i`: `rdf:List`<br>`$o`: `rdf:List`</div></div><br>
+**Schema**<br>`$s+ math:absoluteValue $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
 **Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%281%29+%282+3%29+%284%29+%29+list%3Aappend+%281+2+3+4%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+true+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+-2+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3AabsoluteValue+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
         <p>
-Is the list (1 2 3 4) equal to appending (1), (2 3) , (4)?
+Calculate the absolute value of the value -2.
             
         <p><b>Formula:</b>
 ```
 
 @prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
 
-{ ( (1) (2 3) (4) ) list:append (1 2 3 4) . } => { :result :is true . } .
-            
-```
-        <p><b>Result:</b>
-```
+:Let :param -2 .
 
-@prefix : <http://example.org/>.
-:result :is true. 
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%281+2%29+%283+4%29+%29+list%3Aappend+%3Flist+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Flist+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Append (3 4) to the list (1 2).
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ ( (1 2) (3 4) ) list:append ?list . } => { :result :is ?list . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is (1 2 3 4). 
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%281+2%29+%3Fwhat+%29+list%3Aappend+%281+2+3+4%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fwhat+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-What do we need to append to (1 2) to get (1 2 3 4)?
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ ( (1 2) ?what ) list:append (1 2 3 4) . } => { :result :is ?what . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is (3 4). 
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%3Fwhat+%283+4%29+%29+list%3Aappend+%281+2+3+4%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fwhat+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-What do we need to prepend to (3 4) to get (1 2 3 4)?
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ ( ?what (3 4) ) list:append (1 2 3 4) . } => { :result :is ?what . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is (1 2). 
-            
-```
-    </div>
-</div>
-
-### list:first ### {#list:first}
-Gets the first element of the subject list as object.
-
-`true` if and only if `$s` is a list and `$o` is the first member of that list.
-
-**See also**<br><a href="#list:last">list:last</a>
-
-**Schema**<br>`$s+ list:first $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%28%27a%27%29+%7B+%3Aa+%3Ab+%3Ac+%7D+42+%29+list%3Afirst+%3Fwhat+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fwhat+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-What is the first element of ( ('a') { :a :b :c } 42 )?
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ ( ('a') { :a :b :c } 42 ) list:first ?what . } => { :result :is ?what . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is ('a'). 
-            
-```
-    </div>
-</div>
-
-### list:in ### {#list:in}
-Checks whether the subject is a member of the object list.
-
-`true` if and only if `$o` is a list and `$s` is a member of that list.
-
-**See also**<br><a href="#list:member">list:member</a>
-
-**Schema**<br>`$s-[*] list:in $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$o`: `rdf:List`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%22cat%22+list%3Ain+%28+%22dog%22+%22penguin%22+%22cat%22+%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+true+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Does ( "dog" "penguin" "cat" ) contain a "cat"?
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ "cat" list:in ( "dog" "penguin" "cat" ) . } => { :result :is true . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true. 
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%3Fwhat+list%3Ain+%28+%22dog%22+%22penguin%22+%22cat%22+%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fwhat+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-What are the members of ( "dog" "penguin" "cat" )?
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ ?what list:in ( "dog" "penguin" "cat" ) . } => { :result :is ?what . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is "dog" .
-:result :is "penguin" . 
-:result :is "cat" .
-            
-```
-    </div>
-</div>
-
-### list:iterate ### {#list:iterate}
-Iterates over each member of the subject list, getting their index/value pairs as the object.
-
-`true` if and only if `$s` is a list and `$o` is a list with two elements: 
-`$o.1` is a valid index in list `$s` (index starts at 0), and `$o.2` is found at that index in list `$s`.
-
-**Schema**<br>`$s+ list:iterate ( $o.1?[*] $o.2?[*] )?[*]`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`<br>`$o.1`: `xsd:integer`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28%22dog%22+%22penguin%22+%22cat%22%29+list%3Aiterate+%28%3Findex+%3Fmember%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%28%3Findex+%3Fmember%29+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Iterate over the list ("dog" "penguin" "cat").
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ ("dog" "penguin" "cat") list:iterate (?index ?member) . } => { :result :is (?index ?member) . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is (0 "dog") .
-:result :is (1 "penguin") .
-:result :is (2 "cat") .
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22%29+.%0A%7B%0A++++%3Alet+%3Aparam+%3Fparam+.+%0A++++%3Fparam+list%3Aiterate+%282+%22cat%22%29+.++%0A%7D%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+true+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Is "cat" the third item in the list ("dog" "penguin" "cat")?
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-:let :param ("dog" "penguin" "cat") .
 {
-    :let :param ?param . 
-    ?param list:iterate (2 "cat") .  
+    :Let :param ?param .
+    ?param math:absoluteValue ?result .
 }
-=> 
-{ 
-    :result :is true . 
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 2. 
+            
+```
+    </div>
+</div>
+
+### math:acos ### {#math:acos}
+Calculates the object as the arc cosine value of the subject.
+
+`true` if and only if `$o` is the arc cosine value of `$s`.
+
+**See also**<br><a href="#math:cosh">math:cosh</a><br><a href="#math:cos">math:cos</a>
+
+**Schema**<br>`$s? math:acos $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+1+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aacos+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the arc cosine of the value 1.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param 1 .
+
+{
+    :Let :param ?param .
+    ?param math:acos ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 0.0 .
+            
+```
+    </div>
+</div>
+
+### math:asin ### {#math:asin}
+Calculates the object as the arc sine value of the subject.
+
+`true` if and only if `$o` is the arc sine value of `$s`.
+
+**See also**<br><a href="#math:sinh">math:sinh</a><br><a href="#math:sin">math:sin</a>
+
+**Schema**<br>`$s? math:asin $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+1+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aasin+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the arc sine of the value 1.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param 1 .
+
+{
+    :Let :param ?param .
+    ?param math:asin ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 1.5707963267948966 .
+            
+```
+    </div>
+</div>
+
+### math:atan ### {#math:atan}
+Calculates the object as the arc tangent value of the subject.
+
+`true` if and only if `$o` is the arc tangent value of `$s`.
+
+**See also**<br><a href="#math:tan">math:tan</a><br><a href="#math:tanh">math:tanh</a>
+
+**Schema**<br>`$s? math:atan $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+1+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aatan+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the arc tangent of the value 1.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param 1 .
+
+{
+    :Let :param ?param .
+    ?param math:atan ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 0.7853981633974483 .
+            
+```
+    </div>
+</div>
+
+### math:cos ### {#math:cos}
+Calculates the object as the cosine value of the subject.
+
+`true` if and only if `$o` is the cosine value of `$s`.
+
+**See also**<br><a href="#math:acos">math:acos</a><br><a href="#math:cosh">math:cosh</a>
+
+**Schema**<br>`$s? math:cos $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+0+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Acos+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the cosine of the value 0.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param 0 .
+
+{
+    :Let :param ?param .
+    ?param math:cos ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 1.0 .
+            
+```
+    </div>
+</div>
+
+### math:cosh ### {#math:cosh}
+Calculates the object as the hyperbolic cosine value of the subject.
+
+`true` if and only if `$o` is the hyperbolic cosine value of `$s`.
+
+**See also**<br><a href="#math:cos">math:cos</a><br><a href="#math:acos">math:acos</a>
+
+**Schema**<br>`$s? math:cosh $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+0+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Acosh+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the hyperbolic cosine of the value 0.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param 0 .
+
+{
+    :Let :param ?param .
+    ?param math:cosh ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 1.0 .
+            
+```
+    </div>
+</div>
+
+### math:degrees ### {#math:degrees}
+Calculates the object as the value in degrees corresponding to the radians value of the subject.
+
+`true` if and only if `$o` is the value in degrees corresponding to the radians value of `$s`.
+
+**Schema**<br>`$s? math:degrees $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+1.57079632679+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Adegrees+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the degrees of the radians value 1.57079632679.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param 1.57079632679 .
+
+{
+    :Let :param ?param .
+    ?param math:degrees ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 89.99999999971946 .
+            
+```
+    </div>
+</div>
+
+### math:difference ### {#math:difference}
+Calculates the object by subtracting the second number from the first number given in the subject list.
+
+`true` if and only if `$o` is the result of subtracting `$s.2` from `$s.1`.
+
+**Schema**<br>`( $s.1+ $s.2+ )+ math:difference $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: (`xsd:decimal` | `xsd:double` | `xsd:float`), `$s.2`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%287+2%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Adifference+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the value of 7 minus 2.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param (7 2) .
+
+{
+    :Let :param ?param .
+    ?param math:difference ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 5.
+            
+```
+    </div>
+</div>
+
+### math:equalTo ### {#math:equalTo}
+Checks whether the subject and object are the same number.
+
+`true` if and only if `$s` is the same number as `$o`.
+
+**See also**<br><a href="#math:notEqualTo">math:notEqualTo</a>
+
+**Schema**<br>`$s? math:equalTo $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2842+42%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AequalTo+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Check if the numbers 42 and 42 are equal .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param (42 42) .
+
+{
+    :Let :param (?X ?Y) .
+    ?X math:equalTo ?Y .
+}
+=>
+{
+    :result :is true .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true . 
+            
+```
+    </div>
+</div>
+
+### math:exponentiation ### {#math:exponentiation}
+Calculates the object as the result of raising the first number to the power of the second number in the subject list. 
+You can also use this to calculate the logarithm of the object, with as base the first number of the subject list (see examples).
+
+`true` if and only if `$o` is the result of raising `$s.1` to the power of `$s.2`
+
+**Schema**<br>`( $s.1+ $s.2? )+ math:exponentiation $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: (`xsd:decimal` | `xsd:double` | `xsd:float`), `$s.2`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%7B%0A++++%287+%3Fresult%29+math%3Aexponentiation+49+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the logarithm of 49 base 2 .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+{
+    (7 ?result) math:exponentiation 49 .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 2.0 .
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%287+2%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aexponentiation+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the value of 7 raised to the power of 2 .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param (7 2) .
+
+{
+    :Let :param ?param .
+    ?param math:exponentiation ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 49 .
+            
+```
+    </div>
+</div>
+
+### math:greaterThan ### {#math:greaterThan}
+Checks whether the subject is a number that is greater than the object.
+
+`true` if and only if `$s` is a number that is greater than `$o`.
+
+**See also**<br><a href="#math:notGreaterThan">math:notGreaterThan</a>
+
+**Schema**<br>`$s+ math:greaterThan $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2842+41%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AgreaterThan+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Check if 42 is greater than 41 .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param (42 41) .
+
+{
+    :Let :param (?X ?Y) .
+    ?X math:greaterThan ?Y .
+}
+=>
+{
+    :result :is true .
 } .
             
 ```
@@ -580,25 +799,35 @@ Is "cat" the third item in the list ("dog" "penguin" "cat")?
 ```
     </div>
 </div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22%29+.%0A%7B%0A++++%3Alet+%3Aparam+%3Fparam+.+%0A++++%3Fparam+list%3Aiterate+%28%3Findex+%22cat%22%29+.++%0A%7D%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Findex+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+
+### math:lessThan ### {#math:lessThan}
+Checks whether the subject is a number that is less than the object.
+
+`true` if and only if `$s` is a number that is less than `$o`.
+
+**See also**<br><a href="#math:notLessThan">math:notLessThan</a>
+
+**Schema**<br>`$s+ math:lessThan $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2841+42%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AlessThan+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
         <p>
-What is the index of "cat" in the list ("dog" "penguin" "cat")?
+Check if 41 is less than 42 .
             
         <p><b>Formula:</b>
 ```
 
 @prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
 
-:let :param ("dog" "penguin" "cat") .
+:Let :param (41 42) .
+
 {
-    :let :param ?param . 
-    ?param list:iterate (?index "cat") .  
+    :Let :param (?X ?Y) .
+    ?X math:lessThan ?Y .
 }
-=> 
-{ 
-    :result :is ?index . 
+=>
+{
+    :result :is true .
 } .
             
 ```
@@ -606,198 +835,38 @@ What is the index of "cat" in the list ("dog" "penguin" "cat")?
 ```
 
 @prefix : <http://example.org/>.
-:result :is 2 .
+:result :is true .
             
 ```
     </div>
 </div>
 
-### list:last ### {#list:last}
-Gets the last element of the subject list as object.
+### math:negation ### {#math:negation}
+Calculates the object as the negation of the subject.
 
-`true` if and only if `$s` is a list and `$o` is the last member of that list.
+`true` if and only if `$o` is the negation of `$s`.
 
-**See also**<br><a href="#list:first">list:first</a>
-
-**Schema**<br>`$s+ list:last $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`</div></div><br>
+**Schema**<br>`$s? math:negation $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
 **Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%281+2+3+4%29.%0A%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%3Fparam+list%3Alast+4+.+%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+true+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+42+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Anegation+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
         <p>
-Test if the last element of the list (1 2 3 4) is 4.
+Calculate the negation of the value 42 .
             
         <p><b>Formula:</b>
 ```
 
 @prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
 
-:let :param (1 2 3 4).
-
-{ 
-    :let :param ?param .
-    ?param list:last 4 . 
-} 
-=> 
-{ 
-    :result :is true . 
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true. 
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%281+2+3+4%29+list%3Alast+%3Flast+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Flast+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Extract the last element of the list (1 2 3 4).
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ (1 2 3 4) list:last ?last . } => { :result :is ?last . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 4. 
-            
-```
-    </div>
-</div>
-
-### list:length ### {#list:length}
-Gets the length of the subject list as object.
-
-`true` if and only if `$s` is a list and `$o` is the integer length of that list.
-
-**Schema**<br>`$s+ list:length $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%281+2+3+4%29+list%3Alength+%3Flength+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Flength+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the length of the list (1 2 3 4).
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ (1 2 3 4) list:length ?length . } => { :result :is ?length . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 4. 
-            
-```
-    </div>
-</div>
-
-### list:member ### {#list:member}
-Checks whether the subject list contains the object.
-
-`true` if and only if `$s` is a list and `$o` is a member of that list.
-
-**See also**<br><a href="#list:in">list:in</a><br><a href="#list:memberAt">list:memberAt</a>
-
-**Schema**<br>`$s+ list:member $o-[*]`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22%29+.%0A%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%3Fparam+list%3Amember+%22cat%22+.+%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+true+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Is "cat" a member of the list ("dog" "penguin" "cat")?
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-:let :param ("dog" "penguin" "cat") .
-
-{ 
-    :let :param ?param .
-    ?param list:member "cat" . 
-} 
-=> 
-{ 
-    :result :is true . 
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true.
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28%22dog%22+%22penguin%22+%22cat%22%29+list%3Amember+%3Fmember+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fmember+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Determine the members of the list ("dog" "penguin" "cat").
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-{ ("dog" "penguin" "cat") list:member ?member . } => { :result :is ?member . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is "dog".
-:result :is "penguin".
-:result :is "cat".
-            
-```
-    </div>
-</div>
-
-### list:memberAt ### {#list:memberAt}
-Gets the member of the subject list at the given subject index as object (index starts at 0).
-
-`true` if and only if `$s.1` is a list, `$s.2` is a valid index in list `$s.1`, and `$o` is found at that index in the list.
-
-**Schema**<br>`( $s.1+ $s.2?[*] )+ list:memberAt $o?[*]`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `rdf:List`, `$s.2`: `xsd:integer`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22cat%22+%22penguin%22+%22cat%22%29.%0A%0A%7B%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%28+%3Fparam+%3Findex+%29+list%3AmemberAt+%22cat%22+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Findex+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Find the index of "cat" in the list ("dog" "cat" "penguin" "cat").
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
-
-:let :param ("dog" "cat" "penguin" "cat").
+:Let :param 42 .
 
 {
-    :let :param ?param .
-    ( ?param ?index ) list:memberAt "cat" .
-} 
-=> 
-{ 
-    :result :is ?index . 
+    :Let :param ?param .
+    ?param math:negation ?result .
+}
+=>
+{
+    :result :is ?result .
 } .
             
 ```
@@ -805,32 +874,40 @@ Find the index of "cat" in the list ("dog" "cat" "penguin" "cat").
 ```
 
 @prefix : <http://example.org/>.
-:result :is 1 .
-:result :is 3 .
+:result :is -42 .
             
 ```
     </div>
 </div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22%29.%0A%0A%7B%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%28+%3Fparam+2+%29+list%3AmemberAt+%3Fthird+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Fthird+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+
+### math:notEqualTo ### {#math:notEqualTo}
+Checks whether the subject and object are not the same number.
+
+`true` if and only if `$s` is the not same number as `$o`.
+
+**See also**<br><a href="#math:equalTo">math:equalTo</a>
+
+**Schema**<br>`$s+ math:notEqualTo $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2841+42%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AnotEqualTo+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
         <p>
-Get the third member of the list ("dog" "penguin" "cat").
+Check if the numbers 41 and 42 are not equal .
             
         <p><b>Formula:</b>
 ```
 
 @prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
 
-:let :param ("dog" "penguin" "cat").
+:Let :param (41 42) .
 
 {
-    :let :param ?param .
-    ( ?param 2 ) list:memberAt ?third .
-} 
-=> 
-{ 
-    :result :is ?third . 
+    :Let :param (?X ?Y) .
+    ?X math:notEqualTo ?Y .
+}
+=>
+{
+    :result :is true .
 } .
             
 ```
@@ -838,39 +915,41 @@ Get the third member of the list ("dog" "penguin" "cat").
 ```
 
 @prefix : <http://example.org/>.
-:result :is "cat" .
+:result :is true .
             
 ```
     </div>
 </div>
 
-### list:remove ### {#list:remove}
-Removes each occurrence of the subject member from the subject list, and returns the resulting list as object.
+### math:notGreaterThan ### {#math:notGreaterThan}
+Checks whether the subject is a number that is not greater than the object.
+You can use this as an equivalent of a lessThanOrEqual operator.
 
-`true` if and only if `$s.1` is a list, and `$o` is a list composed of the members of `$s.1` with all occurrences of `$s.2` removed (if it was present; else, `$o` will be the same list).
+`true` if and only if `$s` is a number that is not greater than `$o`.
 
-**See also**<br><a href="#list:append">list:append</a>
+**See also**<br><a href="#math:greaterThan">math:greaterThan</a>
 
-**Schema**<br>`( $s.1+ $s.2+ )+ list:remove $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `rdf:List`</div></div><br>
+**Schema**<br>`$s+ math:notGreaterThan $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
 **Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22+%22penguin%22%29+.%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.+%0A++++%28+%3Fparam+%22parakeet%22+%29+list%3Aremove+%3Flist+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Flist+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2841+42%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AnotGreaterThan+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
         <p>
-Remove non-existent "parakeet" from the list ("dog" "penguin" "cat" "penguin").
+Check if 41 is not greater than 42 .
             
         <p><b>Formula:</b>
 ```
 
 @prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
 
-:let :param ("dog" "penguin" "cat" "penguin") .
-{ 
-    :let :param ?param . 
-    ( ?param "parakeet" ) list:remove ?list .
-} 
-=> 
-{ 
-    :result :is ?list . 
+:Let :param (41 42) .
+
+{
+    :Let :param (?X ?Y) .
+    ?X math:notGreaterThan ?Y .
+}
+=>
+{
+    :result :is true .
 } .
             
 ```
@@ -878,30 +957,112 @@ Remove non-existent "parakeet" from the list ("dog" "penguin" "cat" "penguin").
 ```
 
 @prefix : <http://example.org/>.
-:result :is ("dog" "penguin" "cat" "penguin").
+:result :is true .
+            
+```
+    </div>
+</div>
+
+### math:notLessThan ### {#math:notLessThan}
+Checks whether the subject is a number that is not less than the object.
+You can use this as an equivalent of a greaterThanOrEqual operator.
+
+`true` if and only if `$s` is a number that is not less than `$o`.
+
+**See also**<br><a href="#math:lessThan">math:lessThan</a>
+
+**Schema**<br>`$s+ math:notLessThan $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2842+41%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AnotLessThan+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Check if 42 is not less than 41 .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param (42 41) .
+
+{
+    :Let :param (?X ?Y) .
+    ?X math:notLessThan ?Y .
+}
+=>
+{
+    :result :is true .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true .
+            
+```
+    </div>
+</div>
+
+### math:product ### {#math:product}
+Calculates the object as the product of the numbers given in the subject list.
+
+`true` if and only if `$o` is the arithmetic product of all numbers `$s.i`
+
+**Schema**<br>`( $s.i+ )+ math:product $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.i`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%282+21%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aproduct+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the product of 2 and 21.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param (2 21) .
+
+{
+    :Let :param ?param .
+    ?param math:product ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 42.
             
 ```
     </div>
 </div>
 <div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22+%22penguin%22%29+.%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.+%0A++++%28+%3Fparam+%22penguin%22+%29+list%3Aremove+%3Flist+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Flist+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%282+4+6+8%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aproduct+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
         <p>
-Remove "penguin" from the list ("dog" "penguin" "cat" "penguin").
+Calculate the product of 2,4,6, and 8 .
             
         <p><b>Formula:</b>
 ```
 
 @prefix : <http://example.org/>.
-@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
 
-:let :param ("dog" "penguin" "cat" "penguin") .
-{ 
-    :let :param ?param . 
-    ( ?param "penguin" ) list:remove ?list .
-} 
-=> 
-{ 
-    :result :is ?list . 
+:Let :param (2 4 6 8) .
+
+{
+    :Let :param ?param .
+    ?param math:product ?result .
+}
+=>
+{
+    :result :is ?result .
 } .
             
 ```
@@ -909,7 +1070,337 @@ Remove "penguin" from the list ("dog" "penguin" "cat" "penguin").
 ```
 
 @prefix : <http://example.org/>.
-:result :is ("dog" "cat").
+:result :is 384.
+            
+```
+    </div>
+</div>
+
+### math:quotient ### {#math:quotient}
+Calculates the object by dividing the first number by the second number given in the subject list.
+
+`true` if and only if `$o` is the result of dividing `$s.1` by `$s.2`.
+
+**Schema**<br>`( $s.1+ $s.2+ )+ math:quotient $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: (`xsd:decimal` | `xsd:double` | `xsd:float`), `$s.2`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2842+2%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aquotient+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the quotient of 42 and 2.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param (42 2) .
+
+{
+    :Let :param ?param .
+    ?param math:quotient ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 21. 
+            
+```
+    </div>
+</div>
+
+### math:remainder ### {#math:remainder}
+Calculates the object as the remainder of the division of the first integer by the second integer given in the subject list.
+
+`true` if and only if `$o` is the remainder of dividing `$s.1` by `$s.2`.
+
+**Schema**<br>`( $s.1+ $s.2+ )+ math:remainder $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `xsd:integer`, `$s.2`: `xsd:integer`<br>`$o`: `xsd:integer`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2810+3%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aremainder+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the remainder of 10 divided by 3.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param (10 3) .
+
+{
+    :Let :param ?param .
+    ?param math:remainder ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 1.
+            
+```
+    </div>
+</div>
+
+### math:rounded ### {#math:rounded}
+Calculates the object as the integer that is closest to the subject number.
+
+`true` if and only if `$o` is the integer that is closest to `$s`.
+If there are two such numbers, then the one closest to positive infinity is returned.
+
+
+**Schema**<br>`$s+ math:rounded $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: `xsd:integer`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%223.3%22%5E%5Exsd%3Adouble+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Arounded+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the rounded version of 3.3.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Let :param "3.3"^^xsd:double .
+
+{
+    :Let :param ?param .
+    ?param math:rounded ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 3. 
+            
+```
+    </div>
+</div>
+
+### math:sin ### {#math:sin}
+Calculates the object as the sine value of the subject.
+
+`true` if and only if `$o` is the sine value of `$s`.
+
+**See also**<br><a href="#math:asin">math:asin</a><br><a href="#math:sinh">math:sinh</a>
+
+**Schema**<br>`$s? math:sin $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%221.57079632679%22%5E%5Exsd%3Adouble+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Asin+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the sin of pi/2 (1.57079632679) .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Let :param "1.57079632679"^^xsd:double .
+
+{
+    :Let :param ?param .
+    ?param math:sin ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+:result :is "1.0"^^xsd:double . 
+            
+```
+    </div>
+</div>
+
+### math:sinh ### {#math:sinh}
+Calculates the object as the hyperbolic sine value of the subject.
+
+`true` if and only if `$o` is the hyperbolic sine value of `$s`.
+
+**See also**<br><a href="#math:sin">math:sin</a><br><a href="#math:asin">math:asin</a>
+
+**Schema**<br>`$s? math:sinh $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%220.88137358701954302%22%5E%5Exsd%3Adouble.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Asinh+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the sinh of log(1 + sqrt(2)) (0.88137358701954302).
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Let :param "0.88137358701954302"^^xsd:double.
+
+{
+    :Let :param ?param .
+    ?param math:sinh ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 1.0.
+            
+```
+    </div>
+</div>
+
+### math:sum ### {#math:sum}
+Calculates the object as the sum of the numbers given in the subject list.
+
+`true` if and only if `$o` is the arithmetic sum of all numbers `$s.i`
+
+**Schema**<br>`( $s.i+ )+ math:sum $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.i`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%281+2+3+4+5+6+7+8+9+10%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Asum+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the sum of 1,2,3,4,5,6,7,8,9,10.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+:Let :param (1 2 3 4 5 6 7 8 9 10) .
+
+{
+    :Let :param ?param .
+    ?param math:sum ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 55.
+            
+```
+    </div>
+</div>
+
+### math:tan ### {#math:tan}
+Calculates the object as the tangent value of the subject.
+
+`true` if and only if `$o` is the tangent value of `$s`.
+
+**See also**<br><a href="#math:tanh">math:tanh</a><br><a href="#math:atan">math:atan</a>
+
+**Schema**<br>`$s? math:tan $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%220.7853981633974483%22%5E%5Exsd%3Adouble+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Atan+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the tangent of the value 0.7853981633974483 .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Let :param "0.7853981633974483"^^xsd:double .
+
+{
+    :Let :param ?param .
+    ?param math:tan ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+:result :is "0.9999999999999999"^^xsd:double. 
+            
+```
+    </div>
+</div>
+
+### math:tanh ### {#math:tanh}
+Calculates the object as the hyperbolic tangent value of the subject.
+
+`true` if and only if `$o` is the hyperbolic tangent value of `$s`.
+
+**See also**<br><a href="#math:tan">math:tan</a><br><a href="#math:atan">math:atan</a>
+
+**Schema**<br>`$s? math:tanh $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%220.549306%22%5E%5Exsd%3Adouble+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Atanh+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the hyperbolic tanget of 0.549306 .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Let :param "0.549306"^^xsd:double .
+
+{
+    :Let :param ?param .
+    ?param math:tanh ?result .
+}
+=>
+{
+    :result :is ?result .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+:result :is "0.49999989174945103"^^xsd:double. 
             
 ```
     </div>
@@ -1151,6 +1642,1755 @@ Return the minute component of the date "2023-04-01T18:06:04Z" .
 
 @prefix : <http://example.org/>.
 :result :is 2023. 
+            
+```
+    </div>
+</div>
+
+## list ## {#list}
+### list:append ### {#list:append}
+Appends the lists from the subject list into a single list as object.
+
+`true` if and only if `$o` is the concatenation of all lists `$s.i`.
+
+**See also**<br><a href="#list:remove">list:remove</a>
+
+**Schema**<br>`( $s.i?[*] )+ list:append $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.i`: `rdf:List`<br>`$o`: `rdf:List`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%281+2%29+%3Fwhat+%29+list%3Aappend+%281+2+3+4%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fwhat+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+What do we need to append to (1 2) to get (1 2 3 4)?
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ ( (1 2) ?what ) list:append (1 2 3 4) . } => { :result :is ?what . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is (3 4). 
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%281+2%29+%283+4%29+%29+list%3Aappend+%3Flist+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Flist+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Append (3 4) to the list (1 2).
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ ( (1 2) (3 4) ) list:append ?list . } => { :result :is ?list . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is (1 2 3 4). 
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%3Fwhat+%283+4%29+%29+list%3Aappend+%281+2+3+4%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fwhat+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+What do we need to prepend to (3 4) to get (1 2 3 4)?
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ ( ?what (3 4) ) list:append (1 2 3 4) . } => { :result :is ?what . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is (1 2). 
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%281%29+%282+3%29+%284%29+%29+list%3Aappend+%281+2+3+4%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+true+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Is the list (1 2 3 4) equal to appending (1), (2 3) , (4)?
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ ( (1) (2 3) (4) ) list:append (1 2 3 4) . } => { :result :is true . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true. 
+            
+```
+    </div>
+</div>
+
+### list:first ### {#list:first}
+Gets the first element of the subject list as object.
+
+`true` if and only if `$s` is a list and `$o` is the first member of that list.
+
+**See also**<br><a href="#list:last">list:last</a>
+
+**Schema**<br>`$s+ list:first $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28+%28%27a%27%29+%7B+%3Aa+%3Ab+%3Ac+%7D+42+%29+list%3Afirst+%3Fwhat+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fwhat+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+What is the first element of ( ('a') { :a :b :c } 42 )?
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ ( ('a') { :a :b :c } 42 ) list:first ?what . } => { :result :is ?what . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is ('a'). 
+            
+```
+    </div>
+</div>
+
+### list:in ### {#list:in}
+Checks whether the subject is a member of the object list.
+
+`true` if and only if `$o` is a list and `$s` is a member of that list.
+
+**See also**<br><a href="#list:member">list:member</a>
+
+**Schema**<br>`$s-[*] list:in $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$o`: `rdf:List`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%3Fwhat+list%3Ain+%28+%22dog%22+%22penguin%22+%22cat%22+%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fwhat+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+What are the members of ( "dog" "penguin" "cat" )?
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ ?what list:in ( "dog" "penguin" "cat" ) . } => { :result :is ?what . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is "dog" .
+:result :is "penguin" . 
+:result :is "cat" .
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%22cat%22+list%3Ain+%28+%22dog%22+%22penguin%22+%22cat%22+%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+true+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Does ( "dog" "penguin" "cat" ) contain a "cat"?
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ "cat" list:in ( "dog" "penguin" "cat" ) . } => { :result :is true . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true. 
+            
+```
+    </div>
+</div>
+
+### list:iterate ### {#list:iterate}
+Iterates over each member of the subject list, getting their index/value pairs as the object.
+
+`true` if and only if `$s` is a list and `$o` is a list with two elements: 
+`$o.1` is a valid index in list `$s` (index starts at 0), and `$o.2` is found at that index in list `$s`.
+
+**Schema**<br>`$s+ list:iterate ( $o.1?[*] $o.2?[*] )?[*]`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`<br>`$o.1`: `xsd:integer`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22%29+.%0A%7B%0A++++%3Alet+%3Aparam+%3Fparam+.+%0A++++%3Fparam+list%3Aiterate+%28%3Findex+%22cat%22%29+.++%0A%7D%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Findex+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+What is the index of "cat" in the list ("dog" "penguin" "cat")?
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+:let :param ("dog" "penguin" "cat") .
+{
+    :let :param ?param . 
+    ?param list:iterate (?index "cat") .  
+}
+=> 
+{ 
+    :result :is ?index . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 2 .
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22%29+.%0A%7B%0A++++%3Alet+%3Aparam+%3Fparam+.+%0A++++%3Fparam+list%3Aiterate+%282+%22cat%22%29+.++%0A%7D%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+true+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Is "cat" the third item in the list ("dog" "penguin" "cat")?
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+:let :param ("dog" "penguin" "cat") .
+{
+    :let :param ?param . 
+    ?param list:iterate (2 "cat") .  
+}
+=> 
+{ 
+    :result :is true . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true .
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28%22dog%22+%22penguin%22+%22cat%22%29+list%3Aiterate+%28%3Findex+%3Fmember%29+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%28%3Findex+%3Fmember%29+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Iterate over the list ("dog" "penguin" "cat").
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ ("dog" "penguin" "cat") list:iterate (?index ?member) . } => { :result :is (?index ?member) . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is (0 "dog") .
+:result :is (1 "penguin") .
+:result :is (2 "cat") .
+            
+```
+    </div>
+</div>
+
+### list:last ### {#list:last}
+Gets the last element of the subject list as object.
+
+`true` if and only if `$s` is a list and `$o` is the last member of that list.
+
+**See also**<br><a href="#list:first">list:first</a>
+
+**Schema**<br>`$s+ list:last $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%281+2+3+4%29+list%3Alast+%3Flast+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Flast+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Extract the last element of the list (1 2 3 4).
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ (1 2 3 4) list:last ?last . } => { :result :is ?last . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 4. 
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%281+2+3+4%29.%0A%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%3Fparam+list%3Alast+4+.+%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+true+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Test if the last element of the list (1 2 3 4) is 4.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+:let :param (1 2 3 4).
+
+{ 
+    :let :param ?param .
+    ?param list:last 4 . 
+} 
+=> 
+{ 
+    :result :is true . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true. 
+            
+```
+    </div>
+</div>
+
+### list:length ### {#list:length}
+Gets the length of the subject list as object.
+
+`true` if and only if `$s` is a list and `$o` is the integer length of that list.
+
+**Schema**<br>`$s+ list:length $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%281+2+3+4%29+list%3Alength+%3Flength+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Flength+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Calculate the length of the list (1 2 3 4).
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ (1 2 3 4) list:length ?length . } => { :result :is ?length . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 4. 
+            
+```
+    </div>
+</div>
+
+### list:member ### {#list:member}
+Checks whether the subject list contains the object.
+
+`true` if and only if `$s` is a list and `$o` is a member of that list.
+
+**See also**<br><a href="#list:in">list:in</a><br><a href="#list:memberAt">list:memberAt</a>
+
+**Schema**<br>`$s+ list:member $o-[*]`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `rdf:List`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%7B+%28%22dog%22+%22penguin%22+%22cat%22%29+list%3Amember+%3Fmember+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fmember+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Determine the members of the list ("dog" "penguin" "cat").
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+{ ("dog" "penguin" "cat") list:member ?member . } => { :result :is ?member . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is "dog".
+:result :is "penguin".
+:result :is "cat".
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22%29+.%0A%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%3Fparam+list%3Amember+%22cat%22+.+%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+true+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Is "cat" a member of the list ("dog" "penguin" "cat")?
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+:let :param ("dog" "penguin" "cat") .
+
+{ 
+    :let :param ?param .
+    ?param list:member "cat" . 
+} 
+=> 
+{ 
+    :result :is true . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true.
+            
+```
+    </div>
+</div>
+
+### list:memberAt ### {#list:memberAt}
+Gets the member of the subject list at the given subject index as object (index starts at 0).
+
+`true` if and only if `$s.1` is a list, `$s.2` is a valid index in list `$s.1`, and `$o` is found at that index in the list.
+
+**Schema**<br>`( $s.1+ $s.2?[*] )+ list:memberAt $o?[*]`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `rdf:List`, `$s.2`: `xsd:integer`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22%29.%0A%0A%7B%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%28+%3Fparam+2+%29+list%3AmemberAt+%3Fthird+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Fthird+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Get the third member of the list ("dog" "penguin" "cat").
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+:let :param ("dog" "penguin" "cat").
+
+{
+    :let :param ?param .
+    ( ?param 2 ) list:memberAt ?third .
+} 
+=> 
+{ 
+    :result :is ?third . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is "cat" .
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22cat%22+%22penguin%22+%22cat%22%29.%0A%0A%7B%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%28+%3Fparam+%3Findex+%29+list%3AmemberAt+%22cat%22+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Findex+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Find the index of "cat" in the list ("dog" "cat" "penguin" "cat").
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+:let :param ("dog" "cat" "penguin" "cat").
+
+{
+    :let :param ?param .
+    ( ?param ?index ) list:memberAt "cat" .
+} 
+=> 
+{ 
+    :result :is ?index . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 1 .
+:result :is 3 .
+            
+```
+    </div>
+</div>
+
+### list:remove ### {#list:remove}
+Removes each occurrence of the subject member from the subject list, and returns the resulting list as object.
+
+`true` if and only if `$s.1` is a list, and `$o` is a list composed of the members of `$s.1` with all occurrences of `$s.2` removed (if it was present; else, `$o` will be the same list).
+
+**See also**<br><a href="#list:append">list:append</a>
+
+**Schema**<br>`( $s.1+ $s.2+ )+ list:remove $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `rdf:List`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22+%22penguin%22%29+.%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.+%0A++++%28+%3Fparam+%22parakeet%22+%29+list%3Aremove+%3Flist+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Flist+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Remove non-existent "parakeet" from the list ("dog" "penguin" "cat" "penguin").
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+:let :param ("dog" "penguin" "cat" "penguin") .
+{ 
+    :let :param ?param . 
+    ( ?param "parakeet" ) list:remove ?list .
+} 
+=> 
+{ 
+    :result :is ?list . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is ("dog" "penguin" "cat" "penguin").
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+list%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flist%23%3E+.%0A%0A%3Alet+%3Aparam+%28%22dog%22+%22penguin%22+%22cat%22+%22penguin%22%29+.%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.+%0A++++%28+%3Fparam+%22penguin%22+%29+list%3Aremove+%3Flist+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Flist+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Remove "penguin" from the list ("dog" "penguin" "cat" "penguin").
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+
+:let :param ("dog" "penguin" "cat" "penguin") .
+{ 
+    :let :param ?param . 
+    ( ?param "penguin" ) list:remove ?list .
+} 
+=> 
+{ 
+    :result :is ?list . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is ("dog" "cat").
+            
+```
+    </div>
+</div>
+
+## log ## {#log}
+### log:collectAllIn ### {#log:collectAllIn}
+Collects all values matching a given clause and adds them to a list.
+
+`true` if and only if,  for every valid substitution of clause `$s.2`, 
+    i.e., a substitution of variables with terms that generates an instance of `$s.2` that is contained in the scope, 
+    the instance of `$s.1` generated by the same substitution is a member of list `$s.3`. 
+This applies scoped quantification.
+
+**Schema**<br>`( $s.1- $s.2+ $s.3- )+ log:collectAllIn $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.2`: `log:Formula`, `$s.3`: `rdf:List`<br>`$o`: (Scope of the builtin. Leave as a variable to use current N3 document as scope.)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%40prefix+string%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fstring%23%3E+.%0A%0A%3ALet+%3Aparam+%22Huey%22+.%0A%3ALet+%3Aparam+%22Dewey%22+.%0A%3ALet+%3Aparam+%22Louie%22+.%0A%0A%7B%0A++++%28+%3Fparam+%7B+%3ALet+%3Aparam+%3Fparam+%7D+%28%22Huey%22+%22Dewey%22+%22Louie%22%29+%29+log%3AcollectAllIn+_%3Ax+.%0A%7D%0A%3D%3E+%0A%7B+++%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Example where the list is already given; in that case, the collected list will be compared with the given list.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+@prefix string: <http://www.w3.org/2000/10/swap/string#> .
+
+:Let :param "Huey" .
+:Let :param "Dewey" .
+:Let :param "Louie" .
+
+{
+    ( ?param { :Let :param ?param } ("Huey" "Dewey" "Louie") ) log:collectAllIn _:x .
+}
+=> 
+{   
+    :result :is true .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+
+:result :is true .
+
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%40prefix+string%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fstring%23%3E+.%0A%0A%3ALet+%3Aparam+%22Huey%22+.%0A%3ALet+%3Aparam+%22Dewey%22+.%0A%3ALet+%3Aparam+%22Louie%22+.%0A%0A%7B%0A++++%28+%3Fparam+%7B+%3ALet+%3Aparam+%3Fparam+%7D+%3FallParams+%29+log%3AcollectAllIn+_%3Ax+.%0A%0A++++%23+Variable+to+be+collected+can+also+be+part+of+a+list+or+graph+term%0A++++%28+%28%3Fparam%29+%7B+%3ALet+%3Aparam+%3Fparam+%7D+%3FnestedParams+%29+log%3AcollectAllIn+_%3Ax+.%0A%0A++++%23+Add+some+extra+criteria+on+variable+values+to+be+collected%0A++++%28+%3Fparam%0A++++++++%7B+%0A++++++++++++%3ALet+%3Aparam+%3Fparam+.%0A++++++++++++%3Fparam+string%3AlessThan+%22Louie%22++.%0A++++++++%7D+%0A++++++%3FfilteredParams+%29+log%3AcollectAllIn+_%3Ax+.%0A%7D%0A%3D%3E+%0A%7B+++%0A++++%3Aresult1+%3Ais+%3FallParams+.%0A++++%3Aresult2+%3Ais+%3FnestedParams+.%0A++++%3Aresult3+%3Ais+%3FfilteredParams+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Set of basic examples for log:collectAllIn.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+@prefix string: <http://www.w3.org/2000/10/swap/string#> .
+
+:Let :param "Huey" .
+:Let :param "Dewey" .
+:Let :param "Louie" .
+
+{
+    ( ?param { :Let :param ?param } ?allParams ) log:collectAllIn _:x .
+
+    # Variable to be collected can also be part of a list or graph term
+    ( (?param) { :Let :param ?param } ?nestedParams ) log:collectAllIn _:x .
+
+    # Add some extra criteria on variable values to be collected
+    ( ?param
+        { 
+            :Let :param ?param .
+            ?param string:lessThan "Louie"  .
+        } 
+      ?filteredParams ) log:collectAllIn _:x .
+}
+=> 
+{   
+    :result1 :is ?allParams .
+    :result2 :is ?nestedParams .
+    :result3 :is ?filteredParams .
+} .
+
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+
+:result1 :is ("Huey" "Dewey" "Louie").
+:result2 :is (("Huey") ("Dewey") ("Louie")).
+:result3 :is ("Huey" "Dewey").
+
+```
+    </div>
+</div>
+
+### log:conclusion ### {#log:conclusion}
+Gets all possible conclusions from the subject graph term, including rule inferences (deductive closure), as the object graph term.
+
+`true` if and only if `$o` is the set of conclusions which can be drawn from `$s` (deductive closure), 
+by applying any rules it contains to the data it contains.
+
+**Schema**<br>`$s+ log:conclusion $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Formula`<br>`$o`: `log:Formula`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%3Alet+%3Aparam+%7B+%0A++++%3AFelix+a+%3ACat+.+%0A++++%7B+%3FX+a+%3ACat+.+%7D+%3D%3E+%7B+%3FX+%3Asays+%22Meow%22+.+%7D+.%0A%7D+.%0A%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%3Fparam+log%3Aconclusion+%3Fconclusion+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Fconclusion+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Draw all conclusions from the formula ":Felix a :Cat . { ?X a :Cat } => { ?X :says "Meow" . }".
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+:let :param { 
+    :Felix a :Cat . 
+    { ?X a :Cat . } => { ?X :says "Meow" . } .
+} .
+
+{ 
+    :let :param ?param .
+    ?param log:conclusion ?conclusion .
+} 
+=> 
+{ 
+    :result :is ?conclusion . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is {
+    :Felix a :Cat. 
+    :Felix :says "Meow". 
+    { ?S a :Cat . } => { ?S :says "Meow" . } .
+} .
+            
+```
+    </div>
+</div>
+
+### log:conjunction ### {#log:conjunction}
+Merges the graph terms from the subject list into a single graph term as object.
+
+`true` if and only if `$o` is a graph term that is the logical conjunction of each of the graph terms `$s.i` (i.e., includes all their triples, removing any duplicates) .
+
+**Schema**<br>`( $s.i+ )+ log:conjunction $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.i`: `log:Formula`<br>`$o`: `log:Formula`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%28+%7B+%3AFelix+a+%3ACat+.+%7D%0A++++++%7B+%3APluto+a+%3ADog+.+%7D++%0A++++++%7B+%3APingu+a+%3APenguin+.+%7D%0A++++%29+log%3Aconjunction+%3Fmerged+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Fmerged+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Merge the formulas "{ :Felix a :Cat . }" , "{ :Pluto a :Dog . }", "{ :Pingu a :Penguin . }" .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ 
+    ( { :Felix a :Cat . }
+      { :Pluto a :Dog . }  
+      { :Pingu a :Penguin . }
+    ) log:conjunction ?merged .
+} 
+=> 
+{ 
+    :result :is ?merged . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is { 
+    :Felix a :Cat . 
+    :Pingu a :Penguin . 
+    :Pluto a :Dog . 
+} .
+            
+```
+    </div>
+</div>
+
+### log:content ### {#log:content}
+Dereferences the subject IRI and retrieves the online resource as the object string.
+
+`true` if and only if `$o` is a string that represents the online resource to which `$s` is dereferenced.
+
+**Schema**<br>`$s+ log:content $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Uri`<br>`$o`: `xsd:string`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%3Chttps%3A%2F%2Fwww.w3.org%2FPeople%2FBerners-Lee%2Fcard%3E+log%3Acontent+%3Fcontent+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Fcontent+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Fetch the content of https://www.w3.org/People/Berners-Lee/card.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ 
+    <https://www.w3.org/People/Berners-Lee/card> log:content ?content .
+} 
+=> 
+{ 
+    :result :is ?content . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+:result :is "...the content of https://www.w3.org/People/Berners-Lee/card ...". 
+            
+```
+    </div>
+</div>
+
+### log:dtlit ### {#log:dtlit}
+Creates a datatyped literal as object, based on the string value and datatype IRI in the subject list.
+
+`true` if and only if `$o` is a datatyped literal with string value corresponding to `$s.1` and datatype IRI corresponding to `$s.2`.
+
+**See also**<br><a href="#log:langlit">log:langlit</a>
+
+**Schema**<br>`( $s.1? $s.2? )? log:dtlit $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `xsd:string`, `$s.2`: `log:Uri`<br>`$o`: `log:Literal`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%28+%221971-05-05%22+xsd%3Adate+%29+log%3Adtlit+%3Ftyped+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Ftyped+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Create a datatyped literal from the string "1971-05-05" and the type xsd:date.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ ( "1971-05-05" xsd:date ) log:dtlit ?typed } => { :result :is ?typed . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+:result :is "1971-05-05"^^xsd:date.
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%28+%3Fstring+%3Ftype+%29+log%3Adtlit+%221971-05-05%22%5E%5Exsd%3Adate+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%28+%3Fstring+%3Ftype+%29+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Parse the datatyped literal "1971-05-05"^^xsd:date into a string and data type IRI.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ 
+    ( ?string ?type ) log:dtlit "1971-05-05"^^xsd:date .
+} 
+=> 
+{ 
+    :result :is ( ?string ?type ) . 
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+:result :is ("1971-05-05" xsd:date).
+            
+```
+    </div>
+</div>
+
+### log:equalTo ### {#log:equalTo}
+Checks whether the subject and object N3 terms are the same (comparison occurs on the syntax level). 
+Can also be used to bind values to variables (see examples).
+
+`true` if and only if `$s` and `$o` are the same N3 term.
+Not to be confused with owl:sameAs.
+Literals will be compared exactly: their datatypes must be identical (in case of strings, language tags must be identical).
+
+**See also**<br><a href="#log:notEqualTo">log:notEqualTo</a>
+
+**Schema**<br>`$s? log:equalTo $o?`<br><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%23+This+will+fail%0A++++%22Cat%22+log%3AequalTo+%22Cat%22%40en+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Determine if "Cat" is equal to "Cat"@en .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    # This will fail
+    "Cat" log:equalTo "Cat"@en .
+}
+=>
+{
+    :result :is true .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+# no results
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++1+log%3AequalTo+1+.%0A++++%22Cat%22+log%3AequalTo+%22Cat%22+.%0A++++%7B+%3AA+%3AB+%3AC+.+%3AD+%3AE+%3AF+.+%7D+log%3AequalTo+%7B+%3AD+%3AE+%3AF+.+%3AA+%3AB+%3AC+.+%7D+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Determine if 1 is equal to 1 and "Cat" is equal to "Cat" and { :A :B :C . :D :E :F } is equal to { :D :E :F . :A :B :C }.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    1 log:equalTo 1 .
+    "Cat" log:equalTo "Cat" .
+    { :A :B :C . :D :E :F . } log:equalTo { :D :E :F . :A :B :C . } .
+}
+=>
+{
+    :result :is true .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true. 
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%28+%22War+and+Peace%22+%22Leo+Tolstoy%22+1225+%29+log%3AequalTo+%28+%3Ftitle+%3Fauthor+%3FnumPages+%29+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Ftitle+%2C+%3Fauthor+%2C+%3FnumPages+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Assign values from the subject list to universal variables given in the object list. 
+This can be compared to "destructuring" or "unpacking" in programming languages such as JavaScript or Python.
+In contrast to those languages, however, it works in either direction in N3.
+This mechanism works because an effort is made to ensure the truthfulness of builtin statements in N3.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    ( "War and Peace" "Leo Tolstoy" 1225 ) log:equalTo ( ?title ?author ?numPages ) .
+}
+=>
+{
+    :result :is ?title , ?author , ?numPages .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is "War and Peace" , "Leo Tolstoy" , 1225 . # objects can be in any order
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%40prefix+owl%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23%3E+.%0A%0A%3Chttp%3A%2F%2Ffamous.web.site%3E+owl%3AsameAs+%3Chttp%3A%2F%2Fmirror.famous.web.site%3E+.%0A%0A%7B%0A++++%3Chttp%3A%2F%2Ffamous.web.site%3E+log%3AequalTo+%3Chttp%3A%2F%2Ffamous.web.site%3E+.%0A%0A++++%23+But+not%0A++++%23%0A++++%23+%3Chttp%3A%2F%2Ffamous.web.site%3E+log%3AequalTo+%3Chttp%3A%2F%2Fmirror.famous.web.site%3E+.%0A++++%23%0A++++%23+and+not%0A++++%23%0A++++%23+%3Chttp%3A%2F%2Ffamous.web.site%23123%3E+log%3AequalTo+%3Chttp%3A%2F%2Ffamous.web.site%3E+.%0A++++%23%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Determine &lt;http://famous.web.site&gt; is equal to itself .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+<http://famous.web.site> owl:sameAs <http://mirror.famous.web.site> .
+
+{
+    <http://famous.web.site> log:equalTo <http://famous.web.site> .
+
+    # But not
+    #
+    # <http://famous.web.site> log:equalTo <http://mirror.famous.web.site> .
+    #
+    # and not
+    #
+    # <http://famous.web.site#123> log:equalTo <http://famous.web.site> .
+    #
+}
+=>
+{
+    :result :is true .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true. 
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%28+%3Fx+%3Fy+%3Fz+%29+log%3AequalTo+%28+1+2+3+%29%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fx+%2C+%3Fy+%2C+%3Fz+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Assign values from the object list to universal variables given in the subject list. 
+This can be compared to "destructuring" or "unpacking" in programming languages such as JavaScript or Python.
+In contrast to those languages, however, it works in either direction in N3.
+This mechanism works because an effort is made to ensure the truth of builtin statements in N3.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    ( ?x ?y ?z ) log:equalTo ( 1 2 3 )
+}
+=>
+{
+    :result :is ?x , ?y , ?z .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is 1 , 2 , 3 . # objects can be in any order
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++_%3Ax+log%3AequalTo+42+.%0A++++%3Fq++log%3AequalTo+%22Cat%22%40en+.%0A%0A++++%23+This+will+fail+because+_%3Ax+is+already+assigned+to+42+.%0A++++%23+_%3Ax+log%3AequalTo+17+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fq+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Assign a value to an existential or universal variable.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    _:x log:equalTo 42 .
+    ?q  log:equalTo "Cat"@en .
+
+    # This will fail because _:x is already assigned to 42 .
+    # _:x log:equalTo 17 .
+}
+=>
+{
+    :result :is ?q .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is "Cat"@en .
+            
+```
+    </div>
+</div>
+
+### log:forAllIn ### {#log:forAllIn}
+Two clauses are given in the subject list: for every match of the first clause, 
+    the builtin checks whether the second clause also holds for that match.
+
+`true` if and only if, for every valid substitution of clause `$s.1`, 
+    i.e., a substitution of variables with terms that generates an instance of `$s.1` that is contained in the scope, 
+    the instance of `$s.2` generated by the same substitution is also contained in the scope.
+This applies a scoped quantification.
+
+**Schema**<br>`( $s.1+ $s.2+ )+ log:forAllIn $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `log:Formula`, `$s.2`: `log:Formula`<br>`$o`: (Scope of the builtin. Leave as a variable to use current N3 document as scope.)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%3Ac+a+%3ACompositeTask+%3B%0A++++%3AsubTask+%3As1+%2C+%3As2+%2C+%3As3+.%0A%3As1+%3Astate+%3ACompleted+.%0A%3As2+%3Astate+%3ACompleted+.+%0A%3As3+%3Astate+%3ACompleted+.%0A%0A%7B%0A++++%3Fc+a+%3ACompositeTask+.%0A++++%28+%7B+%3Fc+%3AsubTask+%3Fs+%7D+%7B+%3Fs+%3Astate+%3ACompleted+%7D+%29+log%3AforAllIn+_%3At+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+For each subtask of a composite task, check whether the subtask is completed. 
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+:c a :CompositeTask ;
+    :subTask :s1 , :s2 , :s3 .
+:s1 :state :Completed .
+:s2 :state :Completed . 
+:s3 :state :Completed .
+
+{
+    ?c a :CompositeTask .
+    ( { ?c :subTask ?s } { ?s :state :Completed } ) log:forAllIn _:t .
+}
+=>
+{
+    :result :is true .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true. 
+            
+```
+    </div>
+</div>
+
+### log:includes ### {#log:includes}
+Checks whether the subject graph term includes the object graph term (taking into account variables). 
+Can also be used to bind variables to values within the graph contents (see examples).
+
+`true` if and only if there exists some substitution which, when applied to `$s` and `$o`, 
+creates graph terms `$s`' and `$o`' such that every statement in `$o`' is also in `$s`''. 
+Variable substitution is applied recursively to nested compound terms such as graph terms and lists.
+
+**See also**<br><a href="#log:notIncludes">log:notIncludes</a>
+
+**Schema**<br>`$s+ log:includes $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Formula`<br>(Can also be left as a variable to use current N3 document as scope.)<br>`$o`: `log:Formula`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%7B+%3AFelix+a+%3ACat+%7D+log%3Aincludes+%7B+%3FX+a+%3ACat+%7D+.%0A%7D+%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3FX+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Check whether the formula { :Felix a :Cat } includes { ?X a :Cat }.
+
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ 
+    { :Felix a :Cat } log:includes { ?X a :Cat } .
+} 
+=>
+{
+    :result :is ?X .
+} .
+
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is :Felix .
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%3AFelix+a+%3ACat+.%0A%3ATom+a+%3ACat+.%0A%3ARex+a+%3ADog+.%0A%0A%7B+%0A++++_%3At+log%3Aincludes+%7B+%3FX+a+%3ACat+%7D+.%0A%7D+%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3FX+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Check whether the current N3 document includes { ?X a :Cat }.
+
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+:Felix a :Cat .
+:Tom a :Cat .
+:Rex a :Dog .
+
+{ 
+    _:t log:includes { ?X a :Cat } .
+} 
+=>
+{
+    :result :is ?X .
+} .
+
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#>.
+
+:result :is :Felix.
+:result :is :Tom.
+
+```
+    </div>
+</div>
+
+### log:langlit ### {#log:langlit}
+Creates a language-tagged literal as object, based on the string value and language tag (see BCP47) in the subject list.
+
+
+`true` if and only if `$o` is a language-tagged literal with string value corresponding to `$s.1` and language tag corresponding to `$s.2`.
+`$s.2` should be a string in the form of a BCP47 language tag.
+
+**See also**<br><a href="#log:dtlit">log:dtlit</a>
+
+**Schema**<br>`( $s.1? $s.2? )? log:langlit $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `xsd:string`, `$s.2`: `xsd:string`<br>`$o`: `log:Literal`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%7B+%28%22hello%22+%22en%22%29+log%3Alanglit+%3FX+%7D+%3D%3E+%7B+%3FX+a+%3AResult+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Create a language-tagged literal from the string "hello" and language tag "en".
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+{ ("hello" "en") log:langlit ?X } => { ?X a :Result } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+"hello"@en a :Result .
+            
+```
+    </div>
+</div>
+
+### log:notEqualTo ### {#log:notEqualTo}
+Checks whether the subject and object N3 terms are _not_ the same (comparison occurs on the syntax level).
+
+`true` if and only if `$s` and `$o` are _not_ the same N3 term.
+
+**See also**<br><a href="#log:equalTo">log:equalTo</a>
+
+**Schema**<br>`$s+ log:notEqualTo $o+`<br><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A+++%0A++++%7B+%3AA+%3AB+%3AC+.+%7D+log%3AnotEqualTo+%7B+%3AA+%3AB+%3Fc+%7D+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Check whether two graph terms, one containing a universal variable, are not equal.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+   
+    { :A :B :C . } log:notEqualTo { :A :B ?c } .
+}
+=>
+{
+    :result :is true .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+# no result (?c can be unified with :C)
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%22Cat%22+log%3AnotEqualTo+%22Cat%22%40en+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Determine if "Cat" is not equal to "Cat"@en .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    "Cat" log:notEqualTo "Cat"@en .
+}
+=>
+{
+    :result :is true .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true .
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++_%3Ax+log%3AnotEqualTo+42+.%0A++++%3Fq++log%3AnotEqualTo+%22Cat%22%40en+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Check if an existential or universal variable is not equal to a value.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    _:x log:notEqualTo 42 .
+    ?q  log:notEqualTo "Cat"@en .
+}
+=>
+{
+    :result :is true .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+# no result (the variables _:x and ?q are not bounded) 
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++1+log%3AnotEqualTo+2+.%0A++++%22Cat%22+log%3AnotEqualTo+%22CAT%22+.%0A++++%7B+%3AA+%3AB+%3AC+.+%7D+log%3AnotEqualTo+%7B+%3AC+%3AB+%3AA+.+%7D+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Determine if 1 is not equal to 2 and "Cat" is not equal to "CAT" and { :A :B :C . } is not equal to { :C :B :A }.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    1 log:notEqualTo 2 .
+    "Cat" log:notEqualTo "CAT" .
+    { :A :B :C . } log:notEqualTo { :C :B :A . } .
+}
+=>
+{
+    :result :is true .
+} . 
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true .
+            
+```
+    </div>
+</div>
+
+### log:notIncludes ### {#log:notIncludes}
+Checks whether the subject graph term _does not_ include the object graph term (taking into account variables)
+
+`true` if and only if `$s log:includes $o` is `false`.
+
+**See also**<br><a href="#log:includes">log:includes</a>
+
+**Schema**<br>`$s+ log:notIncludes $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Formula`<br>(Can also be left as a variable to use current N3 document as scope.)<br>`$o`: `log:Formula`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%7B+%3AFelix+a+%3ACat+%7D+log%3AnotIncludes+%7B+%3FX+%3Aeats+%3FY+%7D+.%0A%7D+%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Check whether the formula { :Felix a :Cat } does not include { ?X :eats ?Y }.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ 
+    { :Felix a :Cat } log:notIncludes { ?X :eats ?Y } .
+} 
+=>
+{
+    :result :is true .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true.
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%23+Dynamic+evaluation+of+%3FX+and+%3FY%0A++++%3FX+log%3AnotIncludes+%3FY+.%0A++++%3FX+log%3AequalTo+%7B+%3Aa+%3Ab+%3Ac+%7D.%0A++++%3FY+log%3AequalTo+%7B+%3Aa+%3Ab+%3Ad+%7D.%0A%7D+%0A%3D%3E++++++++++++++%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Check whether the formula { :a :b :c } does not include { :a :b :d }.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ 
+    # Dynamic evaluation of ?X and ?Y
+    ?X log:notIncludes ?Y .
+    ?X log:equalTo { :a :b :c }.
+    ?Y log:equalTo { :a :b :d }.
+} 
+=>              
+{
+    :result :is true .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is true.
+            
+```
+    </div>
+</div>
+
+### log:outputString ### {#log:outputString}
+The N3 reasoner will print the object strings in the order of the subject keys, instead of printing the derivations or deductive closure. This may require a reasoner flag to be set.
+
+The concrete semantics of this builtin (e.g., which N3 resource types are supported) will depend on the N3 reasoner.
+
+**Schema**<br>`$s+ log:outputString $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$o`: `xsd:string`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A_%3A2+log%3AoutputString+%22This+is+the+second+line%5Cn%22+.%0A_%3A1+log%3AoutputString+%22This+is+the+first+line%5Cn%22+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Print the two string "This is the first line
+" , "This is the second line
+" to the output.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+_:2 log:outputString "This is the second line\n" .
+_:1 log:outputString "This is the first line\n" .
+            
+```
+        <p><b>Result:</b>
+```
+
+# If the reasoner support the outputString options
+This is the first line
+This is the second line
+            
+```
+    </div>
+</div>
+
+### log:parsedAsN3 ### {#log:parsedAsN3}
+Parses the subject string into an object graph term.
+
+`true` if and only if `$s`, when parsed as N3, gives `$o`.
+`$s` should be a syntactically valid string in N3 format.
+
+**See also**<br><a href="#log:semantics">log:semantics</a>
+
+**Schema**<br>`$s+ log:parsedAsN3 $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `xsd:string`<br>(should be a syntactically valid string in N3 format)<br>`$o`: `log:Formula`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%3ALet+%3Aparam+%22%22%22%0A%40prefix+%3A+%3Curn%3Aexample%3A%3E+.%0A%3ASocrates+a+%3AHuman+.%0A%22%22%22+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3FX+.%0A++++%3FX+log%3AparsedAsN3+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3FY+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Parse the string ':Socrates a :Human .' as N3.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+:Let :param """
+@prefix : <urn:example:> .
+:Socrates a :Human .
+""" .
+
+{
+    :Let :param ?X .
+    ?X log:parsedAsN3 ?Y .
+}
+=>
+{
+    :result :is ?Y .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is { <urn:example:Socrates> a <urn:example:Human> . } .
+            
+```
+    </div>
+</div>
+
+### log:rawType ### {#log:rawType}
+Gets the type of the N3 resource.
+
+`true` if and only if the N3 resource type of `$s` is `$o`.
+N3 resource types include `log:Formula`, `log:Literal`, `rdf:List` or `log:Other`.
+
+**Schema**<br>`$s+ log:rawType $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$o`: `log:Uri`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%281+2+3+4%29+log%3ArawType+%3FlistType+.%0A++++%7B+%3As+%3Ap+%3Ao+%7D+log%3ArawType+%3FgraphType+.%0A%7D+%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%28+%3FlistType+%3FgraphType+%29+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Get the type of lists and graph terms.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    (1 2 3 4) log:rawType ?listType .
+    { :s :p :o } log:rawType ?graphType .
+} 
+=>
+{
+    :result :is ( ?listType ?graphType ) .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+:result :is ( rdf:List log:Formula ) .
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%22Hello%22+log%3ArawType+%3FstringType+.%0A++++42+log%3ArawType+%3FintegerType+.%0A++++true+log%3ArawType+%3FtrueType+.%0A++++false+log%3ArawType+%3FfalseType+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%28+%3FstringType+%3FintegerType+%3FtrueType+%3FfalseType+%29+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Get the type of literal resources.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    "Hello" log:rawType ?stringType .
+    42 log:rawType ?integerType .
+    true log:rawType ?trueType .
+    false log:rawType ?falseType .
+}
+=>
+{
+    :result :is ( ?stringType ?integerType ?trueType ?falseType ) .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+:result :is ( log:Literal log:Literal log:Literal log:Literal ) .
+            
+```
+    </div>
+</div>
+<div class=ex_container >
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%3Chttp%3A%2F%2Fwww.w3c.org%3E+log%3ArawType+%3FresourceType+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3FresourceType+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Get the type of resources.
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    <http://www.w3c.org> log:rawType ?resourceType .
+}
+=>
+{
+    :result :is ?resourceType .
+} .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+:result :is log:Other.
+            
+```
+    </div>
+</div>
+
+### log:semantics ### {#log:semantics}
+Gets as object the graph term that results from parsing an online (N3) string, found by dereferencing the subject IRI.
+
+`true` if and only if `$o` is a graph term that results from parsing the string that results from dereferencing `$s`.
+
+**Schema**<br>`$s+ log:semantics $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Uri`<br>`$o`: `log:Formula`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%3Csemantics.data%3E+log%3Asemantics+%3Fsemantics+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fsemantics+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Read the contents of the file `<semantics.data>` and parse it as Notation3.
+We assume `<semantics.data>` contains the text:
+```       
+  @prefix : <http://example.org/>.
+  :Socrates a :Human .
+```       
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ <semantics.data> log:semantics ?semantics . } => { :result :is ?semantics } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is { :Socrates a :Human . } .
+            
+```
+    </div>
+</div>
+
+### log:semanticsOrError ### {#log:semanticsOrError}
+Either gets as object the graph term that results from parsing an online (N3) string, found by dereferencing the subject IRI; or an error message that explains what went wrong.
+
+`true` if and only if (a) `$o` is a graph term that results from parsing the string that results from dereferencing `$s`; or (b) an error message explaining what went wrong.
+
+**Schema**<br>`$s+ log:semanticsOrError $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Uri`<br>`$o`: (either a log:Formula or xsd:string)</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%3Cerror.data%3E+log%3AsemanticsOrError+%3Fsemantics+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fsemantics+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Read the contents a non existing `<error.data>` and parse it as Notation3 (which of course will fail).
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ <error.data> log:semanticsOrError ?semantics } => { :result :is ?semantics } .
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+
+:result :is "error(existence_error(source_sink,/error.data),context(system:open/4,No such file or directory))" .
+            
+```
+    </div>
+</div>
+
+### log:skolem ### {#log:skolem}
+Gets as object a skolem IRI that is a function of the subject (commonly a list) and a concrete reasoning run (implicit); for one reasoning run, the same subject will always result in the same skolem IRI.
+
+`true` if and only if `$o` is a skolem IRI that is produced by applying a skolem function to the subject.
+
+**Schema**<br>`$s+ log:skolem $o-`<br><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%28%3Aabc+77+%22xyz%22%29+log%3Askolem+%3Fskolem+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fskolem+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Generate a unique Skolem IRI from the list (:abc 77 "xyz") .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ (:abc 77 "xyz") log:skolem ?skolem . } => { :result :is ?skolem } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is <http://www.w3.org/2000/10/swap/genid#zmgk3Vt_z_u7FQlk1NmqIw> . 
+            
+```
+    </div>
+</div>
+
+### log:uri ### {#log:uri}
+Gets as object the string representation of the subject URI.
+
+`true` if and only if `$o` is the string representation of `$s`.
+
+**Schema**<br>`$s? log:uri $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (a URI)<br>`$o`: `xsd:string`</div></div><br>
+**Examples**<br><div class=ex_container style="margin-top: 5px">
+<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%3Chttps%3A%2F%2Fwww.w3.org%3E+log%3Auri+%3Furi+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Furi+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
+        <p>
+Parse the URI <https://www.w3.org> into a string .
+            
+        <p><b>Formula:</b>
+```
+
+@prefix : <http://example.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ <https://www.w3.org> log:uri ?uri . } => { :result :is ?uri . } .
+            
+```
+        <p><b>Result:</b>
+```
+
+@prefix : <http://example.org/>.
+:result :is "https://www.w3.org" .
             
 ```
     </div>
@@ -1813,2246 +4053,6 @@ Checks whether the string "hello world!" starts with "hello" .
 
 @prefix : <http://example.org/>.
 :result :is true . 
-            
-```
-    </div>
-</div>
-
-## log ## {#log}
-### log:collectAllIn ### {#log:collectAllIn}
-Collects all values matching a given clause and adds them to a list.
-
-`true` if and only if,  for every valid substitution of clause `$s.2`, 
-    i.e., a substitution of variables with terms that generates an instance of `$s.2` that is contained in the scope, 
-    the instance of `$s.1` generated by the same substitution is a member of list `$s.3`. 
-This applies scoped quantification.
-
-**Schema**<br>`( $s.1- $s.2+ $s.3- )+ log:collectAllIn $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.2`: `log:Formula`, `$s.3`: `rdf:List`<br>`$o`: (Scope of the builtin. Leave as a variable to use current N3 document as scope.)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%40prefix+string%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fstring%23%3E+.%0A%0A%3ALet+%3Aparam+%22Huey%22+.%0A%3ALet+%3Aparam+%22Dewey%22+.%0A%3ALet+%3Aparam+%22Louie%22+.%0A%0A%7B%0A++++%28+%3Fparam+%7B+%3ALet+%3Aparam+%3Fparam+%7D+%3FallParams+%29+log%3AcollectAllIn+_%3Ax+.%0A%0A++++%23+Variable+to+be+collected+can+also+be+part+of+a+list+or+graph+term%0A++++%28+%28%3Fparam%29+%7B+%3ALet+%3Aparam+%3Fparam+%7D+%3FnestedParams+%29+log%3AcollectAllIn+_%3Ax+.%0A%0A++++%23+Add+some+extra+criteria+on+variable+values+to+be+collected%0A++++%28+%3Fparam%0A++++++++%7B+%0A++++++++++++%3ALet+%3Aparam+%3Fparam+.%0A++++++++++++%3Fparam+string%3AlessThan+%22Louie%22++.%0A++++++++%7D+%0A++++++%3FfilteredParams+%29+log%3AcollectAllIn+_%3Ax+.%0A%7D%0A%3D%3E+%0A%7B+++%0A++++%3Aresult1+%3Ais+%3FallParams+.%0A++++%3Aresult2+%3Ais+%3FnestedParams+.%0A++++%3Aresult3+%3Ais+%3FfilteredParams+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Set of basic examples for log:collectAllIn.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-@prefix string: <http://www.w3.org/2000/10/swap/string#> .
-
-:Let :param "Huey" .
-:Let :param "Dewey" .
-:Let :param "Louie" .
-
-{
-    ( ?param { :Let :param ?param } ?allParams ) log:collectAllIn _:x .
-
-    # Variable to be collected can also be part of a list or graph term
-    ( (?param) { :Let :param ?param } ?nestedParams ) log:collectAllIn _:x .
-
-    # Add some extra criteria on variable values to be collected
-    ( ?param
-        { 
-            :Let :param ?param .
-            ?param string:lessThan "Louie"  .
-        } 
-      ?filteredParams ) log:collectAllIn _:x .
-}
-=> 
-{   
-    :result1 :is ?allParams .
-    :result2 :is ?nestedParams .
-    :result3 :is ?filteredParams .
-} .
-
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-
-:result1 :is ("Huey" "Dewey" "Louie").
-:result2 :is (("Huey") ("Dewey") ("Louie")).
-:result3 :is ("Huey" "Dewey").
-
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%40prefix+string%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fstring%23%3E+.%0A%0A%3ALet+%3Aparam+%22Huey%22+.%0A%3ALet+%3Aparam+%22Dewey%22+.%0A%3ALet+%3Aparam+%22Louie%22+.%0A%0A%7B%0A++++%28+%3Fparam+%7B+%3ALet+%3Aparam+%3Fparam+%7D+%28%22Huey%22+%22Dewey%22+%22Louie%22%29+%29+log%3AcollectAllIn+_%3Ax+.%0A%7D%0A%3D%3E+%0A%7B+++%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Example where the list is already given; in that case, the collected list will be compared with the given list.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-@prefix string: <http://www.w3.org/2000/10/swap/string#> .
-
-:Let :param "Huey" .
-:Let :param "Dewey" .
-:Let :param "Louie" .
-
-{
-    ( ?param { :Let :param ?param } ("Huey" "Dewey" "Louie") ) log:collectAllIn _:x .
-}
-=> 
-{   
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-
-:result :is true .
-
-```
-    </div>
-</div>
-
-### log:conclusion ### {#log:conclusion}
-Gets all possible conclusions from the subject graph term, including rule inferences (deductive closure), as the object graph term.
-
-`true` if and only if `$o` is the set of conclusions which can be drawn from `$s` (deductive closure), 
-by applying any rules it contains to the data it contains.
-
-**Schema**<br>`$s+ log:conclusion $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Formula`<br>`$o`: `log:Formula`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%3Alet+%3Aparam+%7B+%0A++++%3AFelix+a+%3ACat+.+%0A++++%7B+%3FX+a+%3ACat+.+%7D+%3D%3E+%7B+%3FX+%3Asays+%22Meow%22+.+%7D+.%0A%7D+.%0A%0A%7B+%0A++++%3Alet+%3Aparam+%3Fparam+.%0A++++%3Fparam+log%3Aconclusion+%3Fconclusion+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Fconclusion+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Draw all conclusions from the formula ":Felix a :Cat . { ?X a :Cat } => { ?X :says "Meow" . }".
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-:let :param { 
-    :Felix a :Cat . 
-    { ?X a :Cat . } => { ?X :says "Meow" . } .
-} .
-
-{ 
-    :let :param ?param .
-    ?param log:conclusion ?conclusion .
-} 
-=> 
-{ 
-    :result :is ?conclusion . 
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is {
-    :Felix a :Cat. 
-    :Felix :says "Meow". 
-    { ?S a :Cat . } => { ?S :says "Meow" . } .
-} .
-            
-```
-    </div>
-</div>
-
-### log:conjunction ### {#log:conjunction}
-Merges the graph terms from the subject list into a single graph term as object.
-
-`true` if and only if `$o` is a graph term that is the logical conjunction of each of the graph terms `$s.i` (i.e., includes all their triples, removing any duplicates) .
-
-**Schema**<br>`( $s.i+ )+ log:conjunction $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.i`: `log:Formula`<br>`$o`: `log:Formula`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%28+%7B+%3AFelix+a+%3ACat+.+%7D%0A++++++%7B+%3APluto+a+%3ADog+.+%7D++%0A++++++%7B+%3APingu+a+%3APenguin+.+%7D%0A++++%29+log%3Aconjunction+%3Fmerged+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Fmerged+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Merge the formulas "{ :Felix a :Cat . }" , "{ :Pluto a :Dog . }", "{ :Pingu a :Penguin . }" .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ 
-    ( { :Felix a :Cat . }
-      { :Pluto a :Dog . }  
-      { :Pingu a :Penguin . }
-    ) log:conjunction ?merged .
-} 
-=> 
-{ 
-    :result :is ?merged . 
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is { 
-    :Felix a :Cat . 
-    :Pingu a :Penguin . 
-    :Pluto a :Dog . 
-} .
-            
-```
-    </div>
-</div>
-
-### log:content ### {#log:content}
-Dereferences the subject IRI and retrieves the online resource as the object string.
-
-`true` if and only if `$o` is a string that represents the online resource to which `$s` is dereferenced.
-
-**Schema**<br>`$s+ log:content $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Uri`<br>`$o`: `xsd:string`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%3Chttps%3A%2F%2Fwww.w3.org%2FPeople%2FBerners-Lee%2Fcard%3E+log%3Acontent+%3Fcontent+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%3Fcontent+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Fetch the content of https://www.w3.org/People/Berners-Lee/card.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ 
-    <https://www.w3.org/People/Berners-Lee/card> log:content ?content .
-} 
-=> 
-{ 
-    :result :is ?content . 
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-:result :is "...the content of https://www.w3.org/People/Berners-Lee/card ...". 
-            
-```
-    </div>
-</div>
-
-### log:dtlit ### {#log:dtlit}
-Creates a datatyped literal as object, based on the string value and datatype IRI in the subject list.
-
-`true` if and only if `$o` is a datatyped literal with string value corresponding to `$s.1` and datatype IRI corresponding to `$s.2`.
-
-**See also**<br><a href="#log:langlit">log:langlit</a>
-
-**Schema**<br>`( $s.1? $s.2? )? log:dtlit $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `xsd:string`, `$s.2`: `log:Uri`<br>`$o`: `log:Literal`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%28+%3Fstring+%3Ftype+%29+log%3Adtlit+%221971-05-05%22%5E%5Exsd%3Adate+.%0A%7D+%0A%3D%3E+%0A%7B+%0A++++%3Aresult+%3Ais+%28+%3Fstring+%3Ftype+%29+.+%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Parse the datatyped literal "1971-05-05"^^xsd:date into a string and data type IRI.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ 
-    ( ?string ?type ) log:dtlit "1971-05-05"^^xsd:date .
-} 
-=> 
-{ 
-    :result :is ( ?string ?type ) . 
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-:result :is ("1971-05-05" xsd:date).
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%28+%221971-05-05%22+xsd%3Adate+%29+log%3Adtlit+%3Ftyped+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Ftyped+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Create a datatyped literal from the string "1971-05-05" and the type xsd:date.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ ( "1971-05-05" xsd:date ) log:dtlit ?typed } => { :result :is ?typed . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-:result :is "1971-05-05"^^xsd:date.
-            
-```
-    </div>
-</div>
-
-### log:equalTo ### {#log:equalTo}
-Checks whether the subject and object N3 terms are the same (comparison occurs on the syntax level). 
-Can also be used to bind values to variables (see examples).
-
-`true` if and only if `$s` and `$o` are the same N3 term.
-Not to be confused with owl:sameAs.
-Literals will be compared exactly: their datatypes must be identical (in case of strings, language tags must be identical).
-
-**See also**<br><a href="#log:notEqualTo">log:notEqualTo</a>
-
-**Schema**<br>`$s? log:equalTo $o?`<br><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%40prefix+owl%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23%3E+.%0A%0A%3Chttp%3A%2F%2Ffamous.web.site%3E+owl%3AsameAs+%3Chttp%3A%2F%2Fmirror.famous.web.site%3E+.%0A%0A%7B%0A++++%3Chttp%3A%2F%2Ffamous.web.site%3E+log%3AequalTo+%3Chttp%3A%2F%2Ffamous.web.site%3E+.%0A%0A++++%23+But+not%0A++++%23%0A++++%23+%3Chttp%3A%2F%2Ffamous.web.site%3E+log%3AequalTo+%3Chttp%3A%2F%2Fmirror.famous.web.site%3E+.%0A++++%23%0A++++%23+and+not%0A++++%23%0A++++%23+%3Chttp%3A%2F%2Ffamous.web.site%23123%3E+log%3AequalTo+%3Chttp%3A%2F%2Ffamous.web.site%3E+.%0A++++%23%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Determine &lt;http://famous.web.site&gt; is equal to itself .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-
-<http://famous.web.site> owl:sameAs <http://mirror.famous.web.site> .
-
-{
-    <http://famous.web.site> log:equalTo <http://famous.web.site> .
-
-    # But not
-    #
-    # <http://famous.web.site> log:equalTo <http://mirror.famous.web.site> .
-    #
-    # and not
-    #
-    # <http://famous.web.site#123> log:equalTo <http://famous.web.site> .
-    #
-}
-=>
-{
-    :result :is true .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true. 
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%28+%22War+and+Peace%22+%22Leo+Tolstoy%22+1225+%29+log%3AequalTo+%28+%3Ftitle+%3Fauthor+%3FnumPages+%29+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Ftitle+%2C+%3Fauthor+%2C+%3FnumPages+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Assign values from the subject list to universal variables given in the object list. 
-This can be compared to "destructuring" or "unpacking" in programming languages such as JavaScript or Python.
-In contrast to those languages, however, it works in either direction in N3.
-This mechanism works because an effort is made to ensure the truthfulness of builtin statements in N3.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    ( "War and Peace" "Leo Tolstoy" 1225 ) log:equalTo ( ?title ?author ?numPages ) .
-}
-=>
-{
-    :result :is ?title , ?author , ?numPages .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is "War and Peace" , "Leo Tolstoy" , 1225 . # objects can be in any order
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%28+%3Fx+%3Fy+%3Fz+%29+log%3AequalTo+%28+1+2+3+%29%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fx+%2C+%3Fy+%2C+%3Fz+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Assign values from the object list to universal variables given in the subject list. 
-This can be compared to "destructuring" or "unpacking" in programming languages such as JavaScript or Python.
-In contrast to those languages, however, it works in either direction in N3.
-This mechanism works because an effort is made to ensure the truth of builtin statements in N3.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    ( ?x ?y ?z ) log:equalTo ( 1 2 3 )
-}
-=>
-{
-    :result :is ?x , ?y , ?z .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 1 , 2 , 3 . # objects can be in any order
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++1+log%3AequalTo+1+.%0A++++%22Cat%22+log%3AequalTo+%22Cat%22+.%0A++++%7B+%3AA+%3AB+%3AC+.+%3AD+%3AE+%3AF+.+%7D+log%3AequalTo+%7B+%3AD+%3AE+%3AF+.+%3AA+%3AB+%3AC+.+%7D+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Determine if 1 is equal to 1 and "Cat" is equal to "Cat" and { :A :B :C . :D :E :F } is equal to { :D :E :F . :A :B :C }.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    1 log:equalTo 1 .
-    "Cat" log:equalTo "Cat" .
-    { :A :B :C . :D :E :F . } log:equalTo { :D :E :F . :A :B :C . } .
-}
-=>
-{
-    :result :is true .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true. 
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%23+This+will+fail%0A++++%22Cat%22+log%3AequalTo+%22Cat%22%40en+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Determine if "Cat" is equal to "Cat"@en .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    # This will fail
-    "Cat" log:equalTo "Cat"@en .
-}
-=>
-{
-    :result :is true .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-# no results
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++_%3Ax+log%3AequalTo+42+.%0A++++%3Fq++log%3AequalTo+%22Cat%22%40en+.%0A%0A++++%23+This+will+fail+because+_%3Ax+is+already+assigned+to+42+.%0A++++%23+_%3Ax+log%3AequalTo+17+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fq+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Assign a value to an existential or universal variable.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    _:x log:equalTo 42 .
-    ?q  log:equalTo "Cat"@en .
-
-    # This will fail because _:x is already assigned to 42 .
-    # _:x log:equalTo 17 .
-}
-=>
-{
-    :result :is ?q .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is "Cat"@en .
-            
-```
-    </div>
-</div>
-
-### log:forAllIn ### {#log:forAllIn}
-Two clauses are given in the subject list: for every match of the first clause, 
-    the builtin checks whether the second clause also holds for that match.
-
-`true` if and only if, for every valid substitution of clause `$s.1`, 
-    i.e., a substitution of variables with terms that generates an instance of `$s.1` that is contained in the scope, 
-    the instance of `$s.2` generated by the same substitution is also contained in the scope.
-This applies a scoped quantification.
-
-**Schema**<br>`( $s.1+ $s.2+ )+ log:forAllIn $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `log:Formula`, `$s.2`: `log:Formula`<br>`$o`: (Scope of the builtin. Leave as a variable to use current N3 document as scope.)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%3Ac+a+%3ACompositeTask+%3B%0A++++%3AsubTask+%3As1+%2C+%3As2+%2C+%3As3+.%0A%3As1+%3Astate+%3ACompleted+.%0A%3As2+%3Astate+%3ACompleted+.+%0A%3As3+%3Astate+%3ACompleted+.%0A%0A%7B%0A++++%3Fc+a+%3ACompositeTask+.%0A++++%28+%7B+%3Fc+%3AsubTask+%3Fs+%7D+%7B+%3Fs+%3Astate+%3ACompleted+%7D+%29+log%3AforAllIn+_%3At+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-For each subtask of a composite task, check whether the subtask is completed. 
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-:c a :CompositeTask ;
-    :subTask :s1 , :s2 , :s3 .
-:s1 :state :Completed .
-:s2 :state :Completed . 
-:s3 :state :Completed .
-
-{
-    ?c a :CompositeTask .
-    ( { ?c :subTask ?s } { ?s :state :Completed } ) log:forAllIn _:t .
-}
-=>
-{
-    :result :is true .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true. 
-            
-```
-    </div>
-</div>
-
-### log:includes ### {#log:includes}
-Checks whether the subject graph term includes the object graph term (taking into account variables). 
-Can also be used to bind variables to values within the graph contents (see examples).
-
-`true` if and only if there exists some substitution which, when applied to `$s` and `$o`, 
-creates graph terms `$s`' and `$o`' such that every statement in `$o`' is also in `$s`''. 
-Variable substitution is applied recursively to nested compound terms such as graph terms and lists.
-
-**See also**<br><a href="#log:notIncludes">log:notIncludes</a>
-
-**Schema**<br>`$s+ log:includes $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Formula`<br>(Can also be left as a variable to use current N3 document as scope.)<br>`$o`: `log:Formula`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%7B+%3AFelix+a+%3ACat+%7D+log%3Aincludes+%7B+%3FX+a+%3ACat+%7D+.%0A%7D+%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3FX+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check whether the formula { :Felix a :Cat } includes { ?X a :Cat }.
-
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ 
-    { :Felix a :Cat } log:includes { ?X a :Cat } .
-} 
-=>
-{
-    :result :is ?X .
-} .
-
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is :Felix .
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%3AFelix+a+%3ACat+.%0A%3ATom+a+%3ACat+.%0A%3ARex+a+%3ADog+.%0A%0A%7B+%0A++++_%3At+log%3Aincludes+%7B+%3FX+a+%3ACat+%7D+.%0A%7D+%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3FX+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check whether the current N3 document includes { ?X a :Cat }.
-
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-:Felix a :Cat .
-:Tom a :Cat .
-:Rex a :Dog .
-
-{ 
-    _:t log:includes { ?X a :Cat } .
-} 
-=>
-{
-    :result :is ?X .
-} .
-
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#>.
-
-:result :is :Felix.
-:result :is :Tom.
-
-```
-    </div>
-</div>
-
-### log:langlit ### {#log:langlit}
-Creates a language-tagged literal as object, based on the string value and language tag (see BCP47) in the subject list.
-
-
-`true` if and only if `$o` is a language-tagged literal with string value corresponding to `$s.1` and language tag corresponding to `$s.2`.
-`$s.2` should be a string in the form of a BCP47 language tag.
-
-**See also**<br><a href="#log:dtlit">log:dtlit</a>
-
-**Schema**<br>`( $s.1? $s.2? )? log:langlit $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `xsd:string`, `$s.2`: `xsd:string`<br>`$o`: `log:Literal`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%7B+%28%22hello%22+%22en%22%29+log%3Alanglit+%3FX+%7D+%3D%3E+%7B+%3FX+a+%3AResult+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Create a language-tagged literal from the string "hello" and language tag "en".
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-{ ("hello" "en") log:langlit ?X } => { ?X a :Result } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-"hello"@en a :Result .
-            
-```
-    </div>
-</div>
-
-### log:notEqualTo ### {#log:notEqualTo}
-Checks whether the subject and object N3 terms are _not_ the same (comparison occurs on the syntax level).
-
-`true` if and only if `$s` and `$o` are _not_ the same N3 term.
-
-**See also**<br><a href="#log:equalTo">log:equalTo</a>
-
-**Schema**<br>`$s+ log:notEqualTo $o+`<br><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%22Cat%22+log%3AnotEqualTo+%22Cat%22%40en+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Determine if "Cat" is not equal to "Cat"@en .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    "Cat" log:notEqualTo "Cat"@en .
-}
-=>
-{
-    :result :is true .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true .
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++_%3Ax+log%3AnotEqualTo+42+.%0A++++%3Fq++log%3AnotEqualTo+%22Cat%22%40en+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check if an existential or universal variable is not equal to a value.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    _:x log:notEqualTo 42 .
-    ?q  log:notEqualTo "Cat"@en .
-}
-=>
-{
-    :result :is true .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-# no result (the variables _:x and ?q are not bounded) 
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A+++%0A++++%7B+%3AA+%3AB+%3AC+.+%7D+log%3AnotEqualTo+%7B+%3AA+%3AB+%3Fc+%7D+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check whether two graph terms, one containing a universal variable, are not equal.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-   
-    { :A :B :C . } log:notEqualTo { :A :B ?c } .
-}
-=>
-{
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-# no result (?c can be unified with :C)
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++1+log%3AnotEqualTo+2+.%0A++++%22Cat%22+log%3AnotEqualTo+%22CAT%22+.%0A++++%7B+%3AA+%3AB+%3AC+.+%7D+log%3AnotEqualTo+%7B+%3AC+%3AB+%3AA+.+%7D+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Determine if 1 is not equal to 2 and "Cat" is not equal to "CAT" and { :A :B :C . } is not equal to { :C :B :A }.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    1 log:notEqualTo 2 .
-    "Cat" log:notEqualTo "CAT" .
-    { :A :B :C . } log:notEqualTo { :C :B :A . } .
-}
-=>
-{
-    :result :is true .
-} . 
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true .
-            
-```
-    </div>
-</div>
-
-### log:notIncludes ### {#log:notIncludes}
-Checks whether the subject graph term _does not_ include the object graph term (taking into account variables)
-
-`true` if and only if `$s log:includes $o` is `false`.
-
-**See also**<br><a href="#log:includes">log:includes</a>
-
-**Schema**<br>`$s+ log:notIncludes $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Formula`<br>`$o`: `log:Formula`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%23+Dynamic+evaluation+of+%3FX+and+%3FY%0A++++%3FX+log%3AnotIncludes+%3FY+.%0A++++%3FX+log%3AequalTo+%7B+%3Aa+%3Ab+%3Ac+%7D.%0A++++%3FY+log%3AequalTo+%7B+%3Aa+%3Ab+%3Ad+%7D.%0A%7D+%0A%3D%3E++++++++++++++%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check whether the formula { :a :b :c } does not include { :a :b :d }.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ 
-    # Dynamic evaluation of ?X and ?Y
-    ?X log:notIncludes ?Y .
-    ?X log:equalTo { :a :b :c }.
-    ?Y log:equalTo { :a :b :d }.
-} 
-=>              
-{
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true.
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%0A++++%7B+%3AFelix+a+%3ACat+%7D+log%3AnotIncludes+%7B+%3FX+%3Aeats+%3FY+%7D+.%0A%7D+%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check whether the formula { :Felix a :Cat } does not include { ?X :eats ?Y }.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ 
-    { :Felix a :Cat } log:notIncludes { ?X :eats ?Y } .
-} 
-=>
-{
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true.
-            
-```
-    </div>
-</div>
-
-### log:outputString ### {#log:outputString}
-The N3 reasoner will print the object strings in the order of the subject keys, instead of printing the derivations or deductive closure. This may require a reasoner flag to be set.
-
-The concrete semantics of this builtin (e.g., which N3 resource types are supported) will depend on the N3 reasoner.
-
-**Schema**<br>`$s+ log:outputString $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$o`: `xsd:string`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A_%3A2+log%3AoutputString+%22This+is+the+second+line%5Cn%22+.%0A_%3A1+log%3AoutputString+%22This+is+the+first+line%5Cn%22+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Print the two string "This is the first line
-" , "This is the second line
-" to the output.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-_:2 log:outputString "This is the second line\n" .
-_:1 log:outputString "This is the first line\n" .
-            
-```
-        <p><b>Result:</b>
-```
-
-# If the reasoner support the outputString options
-This is the first line
-This is the second line
-            
-```
-    </div>
-</div>
-
-### log:parsedAsN3 ### {#log:parsedAsN3}
-Parses the subject string into an object graph term.
-
-`true` if and only if `$s`, when parsed as N3, gives `$o`.
-`$s` should be a syntactically valid string in N3 format.
-
-**See also**<br><a href="#log:semantics">log:semantics</a>
-
-**Schema**<br>`$s+ log:parsedAsN3 $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `xsd:string`<br>(should be a syntactically valid string in N3 format)<br>`$o`: `log:Formula`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%3ALet+%3Aparam+%22%22%22%0A%40prefix+%3A+%3Curn%3Aexample%3A%3E+.%0A%3ASocrates+a+%3AHuman+.%0A%22%22%22+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3FX+.%0A++++%3FX+log%3AparsedAsN3+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3FY+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Parse the string ':Socrates a :Human .' as N3.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-:Let :param """
-@prefix : <urn:example:> .
-:Socrates a :Human .
-""" .
-
-{
-    :Let :param ?X .
-    ?X log:parsedAsN3 ?Y .
-}
-=>
-{
-    :result :is ?Y .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is { <urn:example:Socrates> a <urn:example:Human> . } .
-            
-```
-    </div>
-</div>
-
-### log:rawType ### {#log:rawType}
-Gets the type of the N3 resource.
-
-`true` if and only if the N3 resource type of `$s` is `$o`.
-N3 resource types include `log:Formula`, `log:Literal`, `rdf:List` or `log:Other`.
-
-**Schema**<br>`$s+ log:rawType $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$o`: `log:Uri`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%281+2+3+4%29+log%3ArawType+%3FlistType+.%0A++++%7B+%3As+%3Ap+%3Ao+%7D+log%3ArawType+%3FgraphType+.%0A%7D+%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%28+%3FlistType+%3FgraphType+%29+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Get the type of lists and graph terms.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    (1 2 3 4) log:rawType ?listType .
-    { :s :p :o } log:rawType ?graphType .
-} 
-=>
-{
-    :result :is ( ?listType ?graphType ) .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-:result :is ( rdf:List log:Formula ) .
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%3Chttp%3A%2F%2Fwww.w3c.org%3E+log%3ArawType+%3FresourceType+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3FresourceType+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Get the type of resources.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    <http://www.w3c.org> log:rawType ?resourceType .
-}
-=>
-{
-    :result :is ?resourceType .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-:result :is log:Other.
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%22Hello%22+log%3ArawType+%3FstringType+.%0A++++42+log%3ArawType+%3FintegerType+.%0A++++true+log%3ArawType+%3FtrueType+.%0A++++false+log%3ArawType+%3FfalseType+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%28+%3FstringType+%3FintegerType+%3FtrueType+%3FfalseType+%29+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Get the type of literal resources.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{
-    "Hello" log:rawType ?stringType .
-    42 log:rawType ?integerType .
-    true log:rawType ?trueType .
-    false log:rawType ?falseType .
-}
-=>
-{
-    :result :is ( ?stringType ?integerType ?trueType ?falseType ) .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-:result :is ( log:Literal log:Literal log:Literal log:Literal ) .
-            
-```
-    </div>
-</div>
-
-### log:semantics ### {#log:semantics}
-Gets as object the graph term that results from parsing an online (N3) string, found by dereferencing the subject IRI.
-
-`true` if and only if `$o` is a graph term that results from parsing the string that results from dereferencing `$s`.
-
-**Schema**<br>`$s+ log:semantics $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Uri`<br>`$o`: `log:Formula`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%3Csemantics.data%3E+log%3Asemantics+%3Fsemantics+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fsemantics+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Read the contents of the file `<semantics.data>` and parse it as Notation3.
-We assume `<semantics.data>` contains the text:
-```       
-  @prefix : <http://example.org/>.
-  :Socrates a :Human .
-```       
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ <semantics.data> log:semantics ?semantics . } => { :result :is ?semantics } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is { :Socrates a :Human . } .
-            
-```
-    </div>
-</div>
-
-### log:semanticsOrError ### {#log:semanticsOrError}
-Either gets as object the graph term that results from parsing an online (N3) string, found by dereferencing the subject IRI; or an error message that explains what went wrong.
-
-`true` if and only if (a) `$o` is a graph term that results from parsing the string that results from dereferencing `$s`; or (b) an error message explaining what went wrong.
-
-**Schema**<br>`$s+ log:semanticsOrError $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: `log:Uri`<br>`$o`: (either a log:Formula or xsd:string)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%3Cerror.data%3E+log%3AsemanticsOrError+%3Fsemantics+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fsemantics+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Read the contents a non existing `<error.data>` and parse it as Notation3 (which of course will fail).
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ <error.data> log:semanticsOrError ?semantics } => { :result :is ?semantics } .
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-
-:result :is "error(existence_error(source_sink,/error.data),context(system:open/4,No such file or directory))" .
-            
-```
-    </div>
-</div>
-
-### log:skolem ### {#log:skolem}
-Gets as object a skolem IRI that is a function of the subject (commonly a list) and a concrete reasoning run (implicit); for one reasoning run, the same subject will always result in the same skolem IRI.
-
-`true` if and only if `$o` is a skolem IRI that is produced by applying a skolem function to the subject.
-
-**Schema**<br>`$s+ log:skolem $o-`<br><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%28%3Aabc+77+%22xyz%22%29+log%3Askolem+%3Fskolem+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Fskolem+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Generate a unique Skolem IRI from the list (:abc 77 "xyz") .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ (:abc 77 "xyz") log:skolem ?skolem . } => { :result :is ?skolem } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is <http://www.w3.org/2000/10/swap/genid#zmgk3Vt_z_u7FQlk1NmqIw> . 
-            
-```
-    </div>
-</div>
-
-### log:uri ### {#log:uri}
-Gets as object the string representation of the subject URI.
-
-`true` if and only if `$o` is the string representation of `$s`.
-
-**Schema**<br>`$s? log:uri $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (a URI)<br>`$o`: `xsd:string`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B+%3Chttps%3A%2F%2Fwww.w3.org%3E+log%3Auri+%3Furi+.+%7D+%3D%3E+%7B+%3Aresult+%3Ais+%3Furi+.+%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Parse the URI <https://www.w3.org> into a string .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-
-{ <https://www.w3.org> log:uri ?uri . } => { :result :is ?uri . } .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is "https://www.w3.org" .
-            
-```
-    </div>
-</div>
-
-## math ## {#math}
-### math:absoluteValue ### {#math:absoluteValue}
-Calculates as object the absolute value of the subject.
-
-`true` if and only if `$o` is the absolute value of `$s`.
-
-**Schema**<br>`$s+ math:absoluteValue $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+-2+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3AabsoluteValue+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the absolute value of the value -2.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param -2 .
-
-{
-    :Let :param ?param .
-    ?param math:absoluteValue ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 2. 
-            
-```
-    </div>
-</div>
-
-### math:acos ### {#math:acos}
-Calculates the object as the arc cosine value of the subject.
-
-`true` if and only if `$o` is the arc cosine value of `$s`.
-
-**See also**<br><a href="#math:cos">math:cos</a><br><a href="#math:cosh">math:cosh</a>
-
-**Schema**<br>`$s? math:acos $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+1+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aacos+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the arc cosine of the value 1.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param 1 .
-
-{
-    :Let :param ?param .
-    ?param math:acos ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 0.0 .
-            
-```
-    </div>
-</div>
-
-### math:asin ### {#math:asin}
-Calculates the object as the arc sine value of the subject.
-
-`true` if and only if `$o` is the arc sine value of `$s`.
-
-**See also**<br><a href="#math:sinh">math:sinh</a><br><a href="#math:sin">math:sin</a>
-
-**Schema**<br>`$s? math:asin $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+1+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aasin+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the arc sine of the value 1.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param 1 .
-
-{
-    :Let :param ?param .
-    ?param math:asin ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 1.5707963267948966 .
-            
-```
-    </div>
-</div>
-
-### math:atan ### {#math:atan}
-Calculates the object as the arc tangent value of the subject.
-
-`true` if and only if `$o` is the arc tangent value of `$s`.
-
-**See also**<br><a href="#math:tan">math:tan</a><br><a href="#math:tanh">math:tanh</a>
-
-**Schema**<br>`$s? math:atan $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+1+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aatan+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the arc tangent of the value 1.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param 1 .
-
-{
-    :Let :param ?param .
-    ?param math:atan ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 0.7853981633974483 .
-            
-```
-    </div>
-</div>
-
-### math:cos ### {#math:cos}
-Calculates the object as the cosine value of the subject.
-
-`true` if and only if `$o` is the cosine value of `$s`.
-
-**See also**<br><a href="#math:acos">math:acos</a><br><a href="#math:cosh">math:cosh</a>
-
-**Schema**<br>`$s? math:cos $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+0+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Acos+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the cosine of the value 0.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param 0 .
-
-{
-    :Let :param ?param .
-    ?param math:cos ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 1.0 .
-            
-```
-    </div>
-</div>
-
-### math:cosh ### {#math:cosh}
-Calculates the object as the hyperbolic cosine value of the subject.
-
-`true` if and only if `$o` is the hyperbolic cosine value of `$s`.
-
-**See also**<br><a href="#math:acos">math:acos</a><br><a href="#math:cos">math:cos</a>
-
-**Schema**<br>`$s? math:cosh $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+0+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Acosh+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the hyperbolic cosine of the value 0.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param 0 .
-
-{
-    :Let :param ?param .
-    ?param math:cosh ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 1.0 .
-            
-```
-    </div>
-</div>
-
-### math:degrees ### {#math:degrees}
-Calculates the object as the value in degrees corresponding to the radians value of the subject.
-
-`true` if and only if `$o` is the value in degrees corresponding to the radians value of `$s`.
-
-**Schema**<br>`$s? math:degrees $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+1.57079632679+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Adegrees+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the degrees of the radians value 1.57079632679.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param 1.57079632679 .
-
-{
-    :Let :param ?param .
-    ?param math:degrees ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 89.99999999971946 .
-            
-```
-    </div>
-</div>
-
-### math:difference ### {#math:difference}
-Calculates the object by subtracting the second number from the first number given in the subject list.
-
-`true` if and only if `$o` is the result of subtracting `$s.2` from `$s.1`.
-
-**Schema**<br>`( $s.1+ $s.2+ )+ math:difference $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: (`xsd:decimal` | `xsd:double` | `xsd:float`), `$s.2`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%287+2%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Adifference+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the value of 7 minus 2.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (7 2) .
-
-{
-    :Let :param ?param .
-    ?param math:difference ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 5.
-            
-```
-    </div>
-</div>
-
-### math:equalTo ### {#math:equalTo}
-Checks whether the subject and object are the same number.
-
-`true` if and only if `$s` is the same number as `$o`.
-
-**See also**<br><a href="#math:notEqualTo">math:notEqualTo</a>
-
-**Schema**<br>`$s? math:equalTo $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2842+42%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AequalTo+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check if the numbers 42 and 42 are equal .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (42 42) .
-
-{
-    :Let :param (?X ?Y) .
-    ?X math:equalTo ?Y .
-}
-=>
-{
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true . 
-            
-```
-    </div>
-</div>
-
-### math:exponentiation ### {#math:exponentiation}
-Calculates the object as the result of raising the first number to the power of the second number in the subject list. 
-You can also use this to calculate the logarithm of the object, with as base the first number of the subject list (see examples).
-
-`true` if and only if `$o` is the result of raising `$s.1` to the power of `$s.2`
-
-**Schema**<br>`( $s.1+ $s.2? )+ math:exponentiation $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: (`xsd:decimal` | `xsd:double` | `xsd:float`), `$s.2`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%7B%0A++++%287+%3Fresult%29+math%3Aexponentiation+49+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the logarithm of 49 base 2 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-{
-    (7 ?result) math:exponentiation 49 .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 2.0 .
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%287+2%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aexponentiation+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the value of 7 raised to the power of 2 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (7 2) .
-
-{
-    :Let :param ?param .
-    ?param math:exponentiation ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 49 .
-            
-```
-    </div>
-</div>
-
-### math:greaterThan ### {#math:greaterThan}
-Checks whether the subject is a number that is greater than the object.
-
-`true` if and only if `$s` is a number that is greater than `$o`.
-
-**See also**<br><a href="#math:notGreaterThan">math:notGreaterThan</a>
-
-**Schema**<br>`$s+ math:greaterThan $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2842+41%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AgreaterThan+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check if 42 is greater than 41 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (42 41) .
-
-{
-    :Let :param (?X ?Y) .
-    ?X math:greaterThan ?Y .
-}
-=>
-{
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true .
-            
-```
-    </div>
-</div>
-
-### math:lessThan ### {#math:lessThan}
-Checks whether the subject is a number that is less than the object.
-
-`true` if and only if `$s` is a number that is less than `$o`.
-
-**See also**<br><a href="#math:notLessThan">math:notLessThan</a>
-
-**Schema**<br>`$s+ math:lessThan $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2841+42%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AlessThan+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check if 41 is less than 42 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (41 42) .
-
-{
-    :Let :param (?X ?Y) .
-    ?X math:lessThan ?Y .
-}
-=>
-{
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true .
-            
-```
-    </div>
-</div>
-
-### math:negation ### {#math:negation}
-Calculates the object as the negation of the subject.
-
-`true` if and only if `$o` is the negation of `$s`.
-
-**Schema**<br>`$s? math:negation $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+42+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Anegation+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the negation of the value 42 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param 42 .
-
-{
-    :Let :param ?param .
-    ?param math:negation ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is -42 .
-            
-```
-    </div>
-</div>
-
-### math:notEqualTo ### {#math:notEqualTo}
-Checks whether the subject and object are not the same number.
-
-`true` if and only if `$s` is the not same number as `$o`.
-
-**See also**<br><a href="#math:equalTo">math:equalTo</a>
-
-**Schema**<br>`$s+ math:notEqualTo $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2841+42%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AnotEqualTo+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check if the numbers 41 and 42 are not equal .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (41 42) .
-
-{
-    :Let :param (?X ?Y) .
-    ?X math:notEqualTo ?Y .
-}
-=>
-{
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true .
-            
-```
-    </div>
-</div>
-
-### math:notGreaterThan ### {#math:notGreaterThan}
-Checks whether the subject is a number that is not greater than the object.
-You can use this as an equivalent of a lessThanOrEqual operator.
-
-`true` if and only if `$s` is a number that is not greater than `$o`.
-
-**See also**<br><a href="#math:greaterThan">math:greaterThan</a>
-
-**Schema**<br>`$s+ math:notGreaterThan $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2841+42%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AnotGreaterThan+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check if 41 is not greater than 42 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (41 42) .
-
-{
-    :Let :param (?X ?Y) .
-    ?X math:notGreaterThan ?Y .
-}
-=>
-{
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true .
-            
-```
-    </div>
-</div>
-
-### math:notLessThan ### {#math:notLessThan}
-Checks whether the subject is a number that is not less than the object.
-You can use this as an equivalent of a greaterThanOrEqual operator.
-
-`true` if and only if `$s` is a number that is not less than `$o`.
-
-**See also**<br><a href="#math:lessThan">math:lessThan</a>
-
-**Schema**<br>`$s+ math:notLessThan $o+`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2842+41%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%28%3FX+%3FY%29+.%0A++++%3FX+math%3AnotLessThan+%3FY+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+true+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Check if 42 is not less than 41 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (42 41) .
-
-{
-    :Let :param (?X ?Y) .
-    ?X math:notLessThan ?Y .
-}
-=>
-{
-    :result :is true .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is true .
-            
-```
-    </div>
-</div>
-
-### math:product ### {#math:product}
-Calculates the object as the product of the numbers given in the subject list.
-
-`true` if and only if `$o` is the arithmetic product of all numbers `$s.i`
-
-**Schema**<br>`( $s.i+ )+ math:product $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.i`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%282+4+6+8%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aproduct+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the product of 2,4,6, and 8 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (2 4 6 8) .
-
-{
-    :Let :param ?param .
-    ?param math:product ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 384.
-            
-```
-    </div>
-</div>
-<div class=ex_container >
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%282+21%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aproduct+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the product of 2 and 21.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (2 21) .
-
-{
-    :Let :param ?param .
-    ?param math:product ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 42.
-            
-```
-    </div>
-</div>
-
-### math:quotient ### {#math:quotient}
-Calculates the object by dividing the first number by the second number given in the subject list.
-
-`true` if and only if `$o` is the result of dividing `$s.1` by `$s.2`.
-
-**Schema**<br>`( $s.1+ $s.2+ )+ math:quotient $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: (`xsd:decimal` | `xsd:double` | `xsd:float`), `$s.2`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2842+2%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aquotient+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the quotient of 42 and 2.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (42 2) .
-
-{
-    :Let :param ?param .
-    ?param math:quotient ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 21. 
-            
-```
-    </div>
-</div>
-
-### math:remainder ### {#math:remainder}
-Calculates the object as the remainder of the division of the first integer by the second integer given in the subject list.
-
-`true` if and only if `$o` is the remainder of dividing `$s.1` by `$s.2`.
-
-**Schema**<br>`( $s.1+ $s.2+ )+ math:remainder $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.1`: `xsd:integer`, `$s.2`: `xsd:integer`<br>`$o`: `xsd:integer`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%2810+3%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Aremainder+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the remainder of 10 divided by 3.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (10 3) .
-
-{
-    :Let :param ?param .
-    ?param math:remainder ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 1.
-            
-```
-    </div>
-</div>
-
-### math:rounded ### {#math:rounded}
-Calculates the object as the integer that is closest to the subject number.
-
-`true` if and only if `$o` is the integer that is closest to `$s`.
-If there are two such numbers, then the one closest to positive infinity is returned.
-
-
-**Schema**<br>`$s+ math:rounded $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: `xsd:integer`</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%223.3%22%5E%5Exsd%3Adouble+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Arounded+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the rounded version of 3.3.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-:Let :param "3.3"^^xsd:double .
-
-{
-    :Let :param ?param .
-    ?param math:rounded ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 3. 
-            
-```
-    </div>
-</div>
-
-### math:sin ### {#math:sin}
-Calculates the object as the sine value of the subject.
-
-`true` if and only if `$o` is the sine value of `$s`.
-
-**See also**<br><a href="#math:sinh">math:sinh</a><br><a href="#math:asin">math:asin</a>
-
-**Schema**<br>`$s? math:sin $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%221.57079632679%22%5E%5Exsd%3Adouble+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Asin+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the sin of pi/2 (1.57079632679) .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-:Let :param "1.57079632679"^^xsd:double .
-
-{
-    :Let :param ?param .
-    ?param math:sin ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-:result :is "1.0"^^xsd:double . 
-            
-```
-    </div>
-</div>
-
-### math:sinh ### {#math:sinh}
-Calculates the object as the hyperbolic sine value of the subject.
-
-`true` if and only if `$o` is the hyperbolic sine value of `$s`.
-
-**See also**<br><a href="#math:sin">math:sin</a><br><a href="#math:asin">math:asin</a>
-
-**Schema**<br>`$s? math:sinh $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%220.88137358701954302%22%5E%5Exsd%3Adouble.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Asinh+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the sinh of log(1 + sqrt(2)) (0.88137358701954302).
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-:Let :param "0.88137358701954302"^^xsd:double.
-
-{
-    :Let :param ?param .
-    ?param math:sinh ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 1.0.
-            
-```
-    </div>
-</div>
-
-### math:sum ### {#math:sum}
-Calculates the object as the sum of the numbers given in the subject list.
-
-`true` if and only if `$o` is the arithmetic sum of all numbers `$s.i`
-
-**Schema**<br>`( $s.i+ )+ math:sum $o-`<div class='schema_where'>where:<div class='schema_datatypes'>`$s.i`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%0A%3ALet+%3Aparam+%281+2+3+4+5+6+7+8+9+10%29+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Asum+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the sum of 1,2,3,4,5,6,7,8,9,10.
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-
-:Let :param (1 2 3 4 5 6 7 8 9 10) .
-
-{
-    :Let :param ?param .
-    ?param math:sum ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-:result :is 55.
-            
-```
-    </div>
-</div>
-
-### math:tan ### {#math:tan}
-Calculates the object as the tangent value of the subject.
-
-`true` if and only if `$o` is the tangent value of `$s`.
-
-**See also**<br><a href="#math:atan">math:atan</a><br><a href="#math:tanh">math:tanh</a>
-
-**Schema**<br>`$s? math:tan $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%220.7853981633974483%22%5E%5Exsd%3Adouble+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Atan+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the tangent of the value 0.7853981633974483 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-:Let :param "0.7853981633974483"^^xsd:double .
-
-{
-    :Let :param ?param .
-    ?param math:tan ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-:result :is "0.9999999999999999"^^xsd:double. 
-            
-```
-    </div>
-</div>
-
-### math:tanh ### {#math:tanh}
-Calculates the object as the hyperbolic tangent value of the subject.
-
-`true` if and only if `$o` is the hyperbolic tangent value of `$s`.
-
-**See also**<br><a href="#math:tan">math:tan</a><br><a href="#math:atan">math:atan</a>
-
-**Schema**<br>`$s? math:tanh $o?`<div class='schema_where'>where:<div class='schema_datatypes'>`$s`: (`xsd:decimal` | `xsd:double` | `xsd:float`)<br>`$o`: (`xsd:decimal` | `xsd:double` | `xsd:float`)</div></div><br>
-**Examples**<br><div class=ex_container style="margin-top: 5px">
-<a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+math%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Fmath%23%3E+.%0A%40prefix+xsd%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E+.%0A%0A%3ALet+%3Aparam+%220.549306%22%5E%5Exsd%3Adouble+.%0A%0A%7B%0A++++%3ALet+%3Aparam+%3Fparam+.%0A++++%3Fparam+math%3Atanh+%3Fresult+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Fresult+.%0A%7D+." target="_blank">try in editor &#128640;</a><div class=example>
-        <p>
-Calculate the hyperbolic tanget of 0.549306 .
-            
-        <p><b>Formula:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix math: <http://www.w3.org/2000/10/swap/math#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-:Let :param "0.549306"^^xsd:double .
-
-{
-    :Let :param ?param .
-    ?param math:tanh ?result .
-}
-=>
-{
-    :result :is ?result .
-} .
-            
-```
-        <p><b>Result:</b>
-```
-
-@prefix : <http://example.org/>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-:result :is "0.49999989174945103"^^xsd:double. 
             
 ```
     </div>

--- a/spec/src/log/notIncludes.n3
+++ b/spec/src/log/notIncludes.n3
@@ -67,8 +67,8 @@ Check whether the formula { :a :b :c } does not include { :a :b :d }.
             fno:predicate "$s" ;
             fno:mode "+" ;
             fnon:position fnon:subject ;
-            fno:type log:Formula
-
+            fno:type log:Formula ;
+            dcterms:description "Can also be left as a variable to use current N3 document as scope." ;
         ] [ a fno:Parameter ;
             fno:predicate "$o" ;
             fno:mode "+" ;


### PR DESCRIPTION
Adding a comment to the notIncludes argument modes that the current N3 document can be used as scope.