### PR TITLE
Fixing #13 adding argument mode comments

### DIFF
--- a/spec/src/log/notIncludes.n3
+++ b/spec/src/log/notIncludes.n3
@@ -67,8 +67,8 @@ Check whether the formula { :a :b :c } does not include { :a :b :d }.
             fno:predicate "$s" ;
             fno:mode "+" ;
             fnon:position fnon:subject ;
-            fno:type log:Formula
-
+            fno:type log:Formula ;
+            dcterms:description "Can also be left as a variable to use current N3 document as scope." ;
         ] [ a fno:Parameter ;
             fno:predicate "$o" ;
             fno:mode "+" ;


### PR DESCRIPTION
Fixing the N3 definition file of the log:notIncludes to add a comment that scopes are allowed.

This pull request does not generate yet a new index.bs file. This will be a seperate issue.