### PR TITLE
Fixing typo in definition of log:includes

### DIFF
--- a/spec/src/log/includes.n3
+++ b/spec/src/log/includes.n3
@@ -12,7 +12,7 @@ log:includes a fno:Function ;
     fnon:tldr """Checks whether the subject graph term includes the object graph term (taking into account variables). 
 Can also be used to bind variables to values within the graph contents (see examples).""" ;
     dcterms:comment """`true` if and only if there exists some substitution which, when applied to `$s` and `$o`, 
-creates graph terms `$s`' and `$o`' such that every statement in `$o`' is also in `$s`''. 
+creates graph terms `$s`' and `$o`' such that every statement in `$o`' is also in `$s`'. 
 Variable substitution is applied recursively to nested compound terms such as graph terms and lists.""" ;
     rdfs:seeAlso log:notIncludes ;
     fno:example ( 


### PR DESCRIPTION
The current definition of log:includes reads:

> true if and only if there exists some substitution which, when applied to $s and $o, creates graph terms $s' and $o' such that every statement in $o' is also in $s''. 

The double prime in the last $s'' should be $s'.